### PR TITLE
use --find-links for pip install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cpu
-          python -m pip install --editable .[dev]
+          python -m pip install --editable .[dev] --find-links https://girder.github.io/large_image_wheels
       - name: Run tests
         # TODO: add more tests...
         run: |


### PR DESCRIPTION
without `--find-links https://girder.github.io/large_image_wheels` an error is raised that `gdal-config` is not found.