### PR TITLE
Add: model weight urls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /work
 ENTRYPOINT ["wsi_run"]
+# Use a writable directory for downloading model weights. Default is ~/.cache, which is
+# not guaranteed to be writable in a Docker container.
+ENV TORCH_HOME=/tmp/torch
 LABEL maintainer="Jakub Kaczmarzyk <jakub.kaczmarzyk@stonybrookmedicine.edu>"

--- a/README.md
+++ b/README.md
@@ -87,13 +87,9 @@ TODO: download model weights.
 CUDA_VISIBLE_DEVICES=0 wsi_run \
     --wsi_dir sample-images/ \
     --results_dir results/ \
-    --patch_size 350 \
-    --um_px 0.25142857142 \
     --model resnet34 \
-    --num_classes 2 \
-    --weights resnet34-brca.pt \
-    --num_workers 8 \
-    --classes notumor,tumor
+    --weights TCGA-BRCA-v1 \
+    --num_workers 8
 ```
 
 ## Run in an Apptainer container (formerly Singularity)
@@ -115,13 +111,9 @@ CUDA_VISIBLE_DEVICES=0 apptainer run \
     patch-classification-pipeline_latest.sif \
         --wsi_dir sample-images/ \
         --results_dir results/ \
-        --patch_size 350 \
-        --um_px 0.25142857142 \
         --model resnet34 \
-        --num_classes 2 \
-        --weights weights/resnet34-brca.pt \
-        --num_workers 8 \
-        --classes notumor,tumor
+        --weights TCGA-BRCA-v1 \
+        --num_workers 8
 ```
 
 ## Run in a Docker container
@@ -157,13 +149,9 @@ docker run --rm -it \
     kaczmarj/patch-classification-pipeline \
         --wsi_dir sample-images/ \
         --results_dir results/ \
-        --patch_size 350 \
-        --um_px 0.25142857142 \
         --model resnet34 \
-        --num_classes 2 \
-        --weights weights/resnet34-brca.pt \
-        --num_workers 2 \
-        --classes notumor,tumor
+        --weights TCGA-BRCA-v1 \
+        --num_workers 2
 ```
 
 ## Output

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ are a type of geometric data structure. Popular whole slide image viewers like Q
 are able to load labels in GeoJSON format.
 
 ```
-wsi_convert_csv_to_geojson results/model-outputs/CMU-1.csv CMU-1.json
+wsi_convert_csv_to_geojson --class-name tumor results/model-outputs/CMU-1.csv CMU-1.json
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ First, pull the Docker image.
 docker pull kaczmarj/patch-classification-pipeline
 ```
 
-This requires the program Docker `>=19.03` and `nvidia-container-runtime-hook`. Please see the
+This requires Docker `>=19.03` and the program `nvidia-container-runtime-hook`. Please see the
 [Docker documentation](https://docs.docker.com/config/containers/resource_constraints/#gpu)
 for more information. If you do not have a GPU installed, you can use CPU by removing
 `--gpus all` from the command below.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ python -m pip install \
     git+https://github.com/kaczmarj/patch-classification-pipeline.git
 ```
 
-TODO: download pretrained weights.
-
 ## Developers
 
 Clone this GitHub repository and install the package (in editable mode with the `dev` extras).
@@ -80,8 +78,6 @@ images in `sample-images/` (only 1 in this example) and will write results to
 `results/`. We set `CUDA_VISIBLE_DEVICES=0` to use the first GPU listed in
 `nvidia-smi`. If you do not have a GPU, model inference can take about 20 minutes.
 (The patch spacing is == 88 um / 350 pixels.)
-
-TODO: download model weights.
 
 ```
 CUDA_VISIBLE_DEVICES=0 wsi_run \

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,13 @@
 [metadata]
 name = wsi_inference
-url = https://github.com/kaczmarzyk/wsi_inference
+url = https://github.com/kaczmarj/patch-classification-pipeline
 author = Jakub Kaczmarzyk
 author_email = jakub.kaczmarzyk@stonybrookmedicine.edu
 description = Run patch-based classification on pathology whole slide images.
+long_description = file: README.md
+long_description_content_type = text/markdown
 license = GNU General Public License v3 (GPLv3)
+license_file = LICENSE
 classifiers =
     Development Status :: 4 - Beta
     Environment :: Console

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,9 @@ install_requires =
     # See https://pytorch.org/get-started/locally/.
     click>=8.0,<9
     h5py
-    large_image[sources]>=1.8.0
+    # The patching module uses OpenSlide so we restrict ourselves to image formats
+    # compatible with OpenSlide.
+    large-image[openslide]>=1.8.0
     numpy
     opencv-python-headless>=4.0.0
     pandas

--- a/wsi_inference/convert_csv_to_geojson.py
+++ b/wsi_inference/convert_csv_to_geojson.py
@@ -73,6 +73,7 @@ def cli(*, input: Path, output: Path):
     GeoJSON files can be used with pathology viewers like QuPath.
 
     INPUT       Path to input CSV
+
     OUTPUT      Path to output GeoJSON file (with .json extension)
     """
     click.echo(f"Reading CSV: {input}")

--- a/wsi_inference/main.py
+++ b/wsi_inference/main.py
@@ -61,8 +61,13 @@ def _print_system_info() -> None:
     print(f"Python version: {platform.python_version()}")
     print(f"  Torch version: {torch.__version__}")
     print(f"  Torchvision version: {torchvision.__version__}")
-    cuda_ver = torch.version.cuda or "NOT FOUND"
-    print(f"  CUDA version: {cuda_ver}")
+    cuda_is_available = torch.cuda.is_available()
+    if cuda_is_available:
+        print("CUDA is available: TRUE")
+        cuda_ver = torch.version.cuda or "NOT FOUND"
+        print(f"  CUDA version: {cuda_ver}")
+    else:
+        print("CUDA is available: FALSE")
     cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", "NOT SET")
     print(f"CUDA_VISIBLE_DEVICES: {cuda_visible_devices}")
     if torch.version.cuda is None:

--- a/wsi_inference/main.py
+++ b/wsi_inference/main.py
@@ -163,11 +163,6 @@ def _print_info() -> None:
     help="Batch size during model inference.",
 )
 @click.option(
-    "--classes",
-    help="Names of the output classes (used in the header of the saved CSV file."
-    " Separate names with commas ('notumor,tumor').'",
-)
-@click.option(
     "--num_workers",
     default=0,
     show_default=True,
@@ -186,7 +181,6 @@ def cli(
     num_classes: int,
     weights: str,
     batch_size: int,
-    classes: typing.Optional[str] = None,
     num_workers: int = 0,
 ):
     """Run model inference on a directory of whole slide images (WSI).
@@ -199,8 +193,7 @@ def cli(
 
     CUDA_VISIBLE_DEVICES=0 wsi_run --wsi_dir slides/ --results_dir results
     --patch_size 350 --um_px 0.250 --model resnet34
-    --weights weights/resnet34.pt --num_classes 2 --batch_size 32
-    --classes notumor,tumor --num_workers 4
+    --weights weights/resnet34.pt --num_classes 2 --batch_size 32 --num_workers 4
     """
 
     wsi_dir = wsi_dir.resolve()
@@ -236,17 +229,6 @@ def cli(
         patch_spacing=um_px,
     )
 
-    classes_list = None
-    if classes is not None:
-        classes_list = classes.split(",")
-        # Convert to set to make sure we don't have any duplicates...
-        # But do not use the set as the new classes list because sets do not preserve
-        # order.
-        if len(set(classes_list)) != num_classes:
-            raise DifferentNumClassesError(
-                f"classes should have length == {num_classes}, got {set(classes_list)}"
-            )
-
     click.secho("\nRunning model inference.\n", fg="green")
     run_inference(
         wsi_dir=wsi_dir,
@@ -258,7 +240,6 @@ def cli(
         weights=weights,
         batch_size=batch_size,
         num_workers=num_workers,
-        classes=classes_list,
     )
 
     click.secho("Finished.", fg="green")

--- a/wsi_inference/main.py
+++ b/wsi_inference/main.py
@@ -149,9 +149,10 @@ def _print_info() -> None:
 )
 @click.option(
     "--weights",
-    type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path),
-    required=True,
-    help="Path to a file containing weights of the model.",
+    type=str,
+    default="TCGA-BRCA-v1",
+    show_default=True,
+    help="Weights to use for the model.",
 )
 @click.option(
     "--batch_size",
@@ -182,7 +183,7 @@ def cli(
     um_px: float,
     model: str,
     num_classes: int,
-    weights: pathlib.Path,
+    weights: str,
     batch_size: int,
     classes: typing.Optional[str] = None,
     num_workers: int = 0,
@@ -203,7 +204,6 @@ def cli(
 
     wsi_dir = wsi_dir.resolve()
     results_dir = results_dir.resolve()
-    weights = weights.resolve()
 
     if not wsi_dir.exists():
         raise FileNotFoundError(f"Whole slide image directory not found: {wsi_dir}")
@@ -216,6 +216,9 @@ def cli(
     files_in_wsi_dir = [p for p in wsi_dir.glob("*") if p.exists()]
     if not files_in_wsi_dir:
         raise FileNotFoundError(f"no files exist in the slide directory: {wsi_dir}")
+
+    if weights != "TCGA-BRCA-v1":
+        raise ctx.fail("Only 'TCGA-BRCA-v1' weights are available at this time.")
 
     _print_info()
 

--- a/wsi_inference/main.py
+++ b/wsi_inference/main.py
@@ -10,6 +10,7 @@ import typing
 
 import click
 
+from .modellib.run_inference import DifferentNumClassesError
 from .modellib.run_inference import run_inference
 from .modellib.models import list_models
 
@@ -238,8 +239,13 @@ def cli(
     classes_list = None
     if classes is not None:
         classes_list = classes.split(",")
-        if len(classes_list) != num_classes:
-            raise ValueError(f"classes should have length == {num_classes}")
+        # Convert to set to make sure we don't have any duplicates...
+        # But do not use the set as the new classes list because sets do not preserve
+        # order.
+        if len(set(classes_list)) != num_classes:
+            raise DifferentNumClassesError(
+                f"classes should have length == {num_classes}, got {set(classes_list)}"
+            )
 
     click.secho("\nRunning model inference.\n", fg="green")
     run_inference(

--- a/wsi_inference/main.py
+++ b/wsi_inference/main.py
@@ -197,7 +197,7 @@ def cli(
     print("---------")
     for key, value in ctx.params.items():
         print(f"{key} = {value}")
-    print("---------")
+    print("---------\n")
 
     # Get model before running the patching script because we need to get the necessary
     # spacing and patch size.

--- a/wsi_inference/main.py
+++ b/wsi_inference/main.py
@@ -65,18 +65,17 @@ def _print_system_info() -> None:
     print(f"  CUDA version: {cuda_ver}")
     cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", "NOT SET")
     print(f"CUDA_VISIBLE_DEVICES: {cuda_visible_devices}")
-
     if torch.version.cuda is None:
         click.secho("\n*******************************************", fg="yellow")
         click.secho("GPU WILL NOT BE USED", fg="yellow")
         if torch.version.cuda is None:
-            click.secho("  CPU-only version of PyTorch is being used", fg="yellow")
+            click.secho("  CPU-only version of PyTorch", fg="yellow")
         click.secho("*******************************************", fg="yellow")
-    elif cuda_visible_devices == "NOT SET" or cuda_visible_devices == "":
+    elif not torch.cuda.is_available():
         click.secho("\n*******************************************", fg="yellow")
         click.secho("GPU WILL NOT BE USED", fg="yellow")
         if torch.version.cuda is None:
-            click.secho("  CUDA_VISIBLE_DEVICES empty or not set", fg="yellow")
+            click.secho("  CUDA DEVICES NOT AVAILABLE", fg="yellow")
         click.secho("*******************************************", fg="yellow")
 
 

--- a/wsi_inference/main.py
+++ b/wsi_inference/main.py
@@ -63,11 +63,11 @@ def _print_system_info() -> None:
     print(f"  Torchvision version: {torchvision.__version__}")
     cuda_is_available = torch.cuda.is_available()
     if cuda_is_available:
-        print("CUDA is available: TRUE")
+        click.secho("GPU available", fg="green")
         cuda_ver = torch.version.cuda or "NOT FOUND"
         print(f"  CUDA version: {cuda_ver}")
     else:
-        print("CUDA is available: FALSE")
+        click.secho("GPU not available", bg="red", fg="black")
     cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", "NOT SET")
     print(f"CUDA_VISIBLE_DEVICES: {cuda_visible_devices}")
     if torch.version.cuda is None:

--- a/wsi_inference/main.py
+++ b/wsi_inference/main.py
@@ -10,7 +10,6 @@ import typing
 
 import click
 
-from .modellib.run_inference import DifferentNumClassesError
 from .modellib.run_inference import run_inference
 from .modellib.models import list_models
 

--- a/wsi_inference/modellib/models.py
+++ b/wsi_inference/modellib/models.py
@@ -11,7 +11,6 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Tuple
 from typing import Union
 
 from PIL import Image

--- a/wsi_inference/modellib/models.py
+++ b/wsi_inference/modellib/models.py
@@ -11,6 +11,7 @@ import pathlib
 import typing
 
 import torch
+from torch.hub import load_state_dict_from_url
 import torchvision
 
 from .inceptionv4 import inceptionv4 as _inceptionv4
@@ -18,39 +19,53 @@ from .inceptionv4 import InceptionV4 as _InceptionV4
 
 # TODO: consider adding the color normalization and input size here. Or maybe as a
 # command line argument.
+# One way forward is to follow in Torchvision's footsteps and create a Weights dataclass
+# to hold the url, transform function, and metadata. That is easy enough, but then how
+# do we associate each model with its available weights? Torchvision uses subclassed
+# enums but for this project, let's go with something simpler.
 
 PathType = typing.Union[str, pathlib.Path]
 
 
-def inceptionv4(num_classes: int, state_dict_path=None) -> _InceptionV4:
+def inceptionv4(num_classes: int, weights="TCGA-BRCA-v1") -> _InceptionV4:
     """Create InceptionV4 model."""
     model = _inceptionv4(num_classes=num_classes, pretrained=False)
-    if state_dict_path is not None:
+    if weights == "TCGA-BRCA-v1":
         print("Loading state dict")
-        print(f"  {state_dict_path}")
-        state_dict = torch.load(state_dict_path, map_location="cpu")
+        state_dict = load_state_dict_from_url(
+            url="https://stonybrookmedicine.box.com/shared/static/tfwimlf3ygyga1x4fnn03u9y5uio8gqk.pt",  # noqa
+            check_hash=True,
+            file_name="inceptionv4-brca-20190613-aef40942.pt",
+        )
         model.load_state_dict(state_dict, strict=True)
+    else:
+        raise NotImplementedError("only TCGA-BRCA-v1 is available now.")
     return model
 
 
-def resnet34(num_classes: int, state_dict_path=None) -> torchvision.models.ResNet:
+def resnet34(num_classes: int, weights="TCGA-BRCA-v1") -> torchvision.models.ResNet:
     """Create ResNet34 model."""
     model = torchvision.models.resnet34()
     model.fc = torch.nn.Linear(model.fc.in_features, num_classes)
-    if state_dict_path is not None:
+    if weights == "TCGA-BRCA-v1":
         print("Loading state dict")
-        print(f"  {state_dict_path}")
-        state_dict = torch.load(state_dict_path, map_location="cpu")
+        state_dict = load_state_dict_from_url(
+            url="https://stonybrookmedicine.box.com/shared/static/dv5bxk6d15uhmcegs9lz6q70yrmwx96p.pt",  # noqa
+            check_hash=True,
+            file_name="resnet34-brca-20190613-01eaf604.pt",
+        )
         model.load_state_dict(state_dict, strict=True)
+    else:
+        raise NotImplementedError("only TCGA-BRCA-v1 is available now.")
     return model
 
 
-def vgg16_modified(num_classes: int, state_dict_path=None) -> torch.nn.Module:
+def vgg16_modified(num_classes: int, weights="TCGA-BRCA-v1") -> torch.nn.Module:
     """Create modified VGG16 model.
 
     The classifier of this model is
         Linear (25,088, 4096)
-        ReLU → Dropout
+        ReLU -> Dropout
         Linear (1024, num_classes)
     """
     model = torchvision.models.vgg16()
@@ -58,11 +73,16 @@ def vgg16_modified(num_classes: int, state_dict_path=None) -> torch.nn.Module:
     in_features = model.classifier[0].in_features
     model.classifier[0] = torch.nn.Linear(in_features, 1024)
     model.classifier[3] = torch.nn.Linear(1024, num_classes)
-    if state_dict_path is not None:
+    if weights == "TCGA-BRCA-v1":
         print("Loading state dict")
-        print(f"  {state_dict_path}")
-        state_dict = torch.load(state_dict_path, map_location="cpu")
+        state_dict = load_state_dict_from_url(
+            url="https://stonybrookmedicine.box.com/shared/static/197s56yvcrdpan7eu5tq8d4gxvq3xded.pt",  # noqa
+            check_hash=True,
+            file_name="vgg16-modified-brca-20190613-62bc1b41.pt",
+        )
         model.load_state_dict(state_dict, strict=True)
+    else:
+        raise NotImplementedError("only TCGA-BRCA-v1 is available now.")
     return model
 
 
@@ -84,7 +104,7 @@ def list_models() -> typing.List[str]:
 def create_model(
     model_name: str,
     num_classes: int,
-    state_dict_path: typing.Optional[PathType] = None,
+    weights: str = "TCGA-BRCA-v1",
 ) -> torch.nn.Module:
     """Create a model."""
     if model_name not in MODELS.keys():
@@ -92,4 +112,4 @@ def create_model(
             f"{model_name} not found. Available models are {MODELS.keys()}"
         )
     model_fn = MODELS[model_name]
-    return model_fn(num_classes=num_classes, state_dict_path=state_dict_path)
+    return model_fn(num_classes=num_classes, weights=weights)

--- a/wsi_inference/modellib/models.py
+++ b/wsi_inference/modellib/models.py
@@ -2,65 +2,141 @@
 
 See https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7369575/table/tbl3/ for modifications
 that were made to the original architectures.
-
-All model functions must have the signature:
-    Function[[int, Optional[str]], torch.nn.Module]
 """
 
+import dataclasses
 import pathlib
-import typing
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import Union
 
+from PIL import Image
 import torch
 from torch.hub import load_state_dict_from_url
 import torchvision
 
 from .inceptionv4 import inceptionv4 as _inceptionv4
-from .inceptionv4 import InceptionV4 as _InceptionV4
+from .transforms import PatchClassification
 
-# TODO: consider adding the color normalization and input size here. Or maybe as a
-# command line argument.
-# One way forward is to follow in Torchvision's footsteps and create a Weights dataclass
-# to hold the url, transform function, and metadata. That is easy enough, but then how
-# do we associate each model with its available weights? Torchvision uses subclassed
-# enums but for this project, let's go with something simpler.
-
-PathType = typing.Union[str, pathlib.Path]
+PathType = Union[str, pathlib.Path]
 
 
-def inceptionv4(num_classes: int, weights="TCGA-BRCA-v1") -> _InceptionV4:
-    """Create InceptionV4 model."""
-    model = _inceptionv4(num_classes=num_classes, pretrained=False)
-    if weights == "TCGA-BRCA-v1":
-        print("Loading state dict")
-        state_dict = load_state_dict_from_url(
+class ModelNotFoundError(Exception):
+    ...
+
+
+class WeightsNotFoundError(Exception):
+    ...
+
+
+@dataclasses.dataclass
+class Weights:
+    """Container for weights URL and associated information."""
+
+    url: str
+    file_name: str
+    num_classes: int
+    transform: Callable[[Union[Image.Image, torch.Tensor]], torch.Tensor]
+    patch_size_pixels: int
+    spacing_um_px: float
+    metadata: Dict[str, Any]
+
+
+# Store all available weights for all models.
+WEIGHTS: Dict[str, Dict[str, Weights]] = {
+    "inceptionv4": {
+        "TCGA-BRCA-v1": Weights(
             url="https://stonybrookmedicine.box.com/shared/static/tfwimlf3ygyga1x4fnn03u9y5uio8gqk.pt",  # noqa
-            check_hash=True,
             file_name="inceptionv4-brca-20190613-aef40942.pt",
-        )
-        model.load_state_dict(state_dict, strict=True)
-    else:
-        raise NotImplementedError("only TCGA-BRCA-v1 is available now.")
-    return model
-
-
-def resnet34(num_classes: int, weights="TCGA-BRCA-v1") -> torchvision.models.ResNet:
-    """Create ResNet34 model."""
-    model = torchvision.models.resnet34()
-    model.fc = torch.nn.Linear(model.fc.in_features, num_classes)
-    if weights == "TCGA-BRCA-v1":
-        print("Loading state dict")
-        state_dict = load_state_dict_from_url(
+            num_classes=2,
+            transform=PatchClassification(
+                resize_size=299,
+                # TODO: check that the mean and std dev are correct.
+                mean=(0.5, 0.5, 0.5),
+                std=(0.5, 0.5, 0.5),
+            ),
+            patch_size_pixels=350,
+            spacing_um_px=88 / 350,
+            metadata={"patch-size": "350 pixels (88 microns)."},
+        ),
+    },
+    "resnet34": {
+        "TCGA-BRCA-v1": Weights(
             url="https://stonybrookmedicine.box.com/shared/static/dv5bxk6d15uhmcegs9lz6q70yrmwx96p.pt",  # noqa
-            check_hash=True,
             file_name="resnet34-brca-20190613-01eaf604.pt",
+            num_classes=2,
+            transform=PatchClassification(
+                resize_size=224,
+                mean=(0.7238, 0.5716, 0.6779),
+                std=(0.1120, 0.1459, 0.1089),
+            ),
+            patch_size_pixels=350,
+            spacing_um_px=88 / 350,
+            metadata={"patch-size": "350 pixels (88 microns)."},
         )
-        model.load_state_dict(state_dict, strict=True)
-    else:
-        raise NotImplementedError("only TCGA-BRCA-v1 is available now.")
+    },
+    "vgg16_modified": {
+        "TCGA-BRCA-v1": Weights(
+            url="https://stonybrookmedicine.box.com/shared/static/197s56yvcrdpan7eu5tq8d4gxvq3xded.pt",  # noqa
+            file_name="vgg16-modified-brca-20190613-62bc1b41.pt",
+            num_classes=2,
+            transform=PatchClassification(
+                resize_size=224,
+                mean=(0.7238, 0.5716, 0.6779),
+                std=(0.1120, 0.1459, 0.1089),
+            ),
+            patch_size_pixels=350,
+            spacing_um_px=88 / 350,
+            metadata={"patch-size": "350 pixels (88 microns)."},
+        )
+    },
+}
+
+
+def _get_model_weights(model_name: str, weights: str) -> Weights:
+    all_weights_for_model = WEIGHTS.get(model_name)
+    if all_weights_for_model is None:
+        raise ModelNotFoundError(f"no weights registered for {model_name}")
+    weights_obj = all_weights_for_model.get(weights)
+    if weights_obj is None:
+        raise WeightsNotFoundError(f"'{weights}' weights not found for {model_name}")
+    return weights_obj
+
+
+def _load_state_into_model(model: torch.nn.Module, weights: Weights):
+    print("Information about the pretrained weights")
+    print("----------------------------------------")
+    for k, v in dataclasses.asdict(weights).items():
+        print(f"{k} = {v}")
+    print("----------------------------------------\n")
+    state_dict = load_state_dict_from_url(
+        url=weights.url, check_hash=True, file_name=weights.file_name
+    )
+    model.load_state_dict(state_dict, strict=True)
     return model
 
 
-def vgg16_modified(num_classes: int, weights="TCGA-BRCA-v1") -> torch.nn.Module:
+def inceptionv4(weights: str = "TCGA-BRCA-v1") -> Tuple[torch.nn.Module, Weights]:
+    """Create InceptionV4 model."""
+    weights_obj = _get_model_weights("inceptionv4", weights=weights)
+    model = _inceptionv4(num_classes=weights_obj.num_classes)
+    model = _load_state_into_model(model=model, weights=weights_obj)
+    return model, weights_obj
+
+
+def resnet34(weights: str = "TCGA-BRCA-v1") -> Tuple[torch.nn.Module, Weights]:
+    """Create ResNet34 model."""
+    weights_obj = _get_model_weights("resnet34", weights=weights)
+    model = torchvision.models.resnet34()
+    model.fc = torch.nn.Linear(model.fc.in_features, weights_obj.num_classes)
+    model = _load_state_into_model(model=model, weights=weights_obj)
+    return model, weights_obj
+
+
+def vgg16_modified(weights="TCGA-BRCA-v1") -> Tuple[torch.nn.Module, Weights]:
     """Create modified VGG16 model.
 
     The classifier of this model is
@@ -68,48 +144,36 @@ def vgg16_modified(num_classes: int, weights="TCGA-BRCA-v1") -> torch.nn.Module:
         ReLU -> Dropout
         Linear (1024, num_classes)
     """
+    weights_obj = _get_model_weights("vgg16_modified", weights=weights)
     model = torchvision.models.vgg16()
     model.classifier = model.classifier[:4]
     in_features = model.classifier[0].in_features
     model.classifier[0] = torch.nn.Linear(in_features, 1024)
-    model.classifier[3] = torch.nn.Linear(1024, num_classes)
-    if weights == "TCGA-BRCA-v1":
-        print("Loading state dict")
-        state_dict = load_state_dict_from_url(
-            url="https://stonybrookmedicine.box.com/shared/static/197s56yvcrdpan7eu5tq8d4gxvq3xded.pt",  # noqa
-            check_hash=True,
-            file_name="vgg16-modified-brca-20190613-62bc1b41.pt",
-        )
-        model.load_state_dict(state_dict, strict=True)
-    else:
-        raise NotImplementedError("only TCGA-BRCA-v1 is available now.")
-    return model
+    model.classifier[3] = torch.nn.Linear(1024, weights_obj.num_classes)
+    model = _load_state_into_model(model=model, weights=weights_obj)
+    return model, weights_obj
 
 
-MODELS: typing.Dict[str, typing.Callable[..., torch.nn.Module]] = dict(
+MODELS = dict(
     inceptionv4=inceptionv4,
     resnet34=resnet34,
     vgg16_modified=vgg16_modified,
 )
 
 
-class ModelNotFoundError(Exception):
-    ...
-
-
-def list_models() -> typing.List[str]:
+def list_models() -> List[str]:
     return list(MODELS.keys())
 
 
 def create_model(
     model_name: str,
-    num_classes: int,
     weights: str = "TCGA-BRCA-v1",
-) -> torch.nn.Module:
+) -> Tuple[torch.nn.Module, Weights]:
     """Create a model."""
     if model_name not in MODELS.keys():
         raise ModelNotFoundError(
             f"{model_name} not found. Available models are {MODELS.keys()}"
         )
     model_fn = MODELS[model_name]
-    return model_fn(num_classes=num_classes, weights=weights)
+    model, weights_obj = model_fn(weights=weights)
+    return model, weights_obj

--- a/wsi_inference/modellib/run_inference.py
+++ b/wsi_inference/modellib/run_inference.py
@@ -29,18 +29,6 @@ from . import models
 PathType = typing.Union[str, pathlib.Path]
 
 
-class DifferentPatchSizeError(Exception):
-    ...
-
-
-class DifferentSpacingError(Exception):
-    ...
-
-
-class DifferentNumClassesError(Exception):
-    ...
-
-
 def _read_patch_coords(path: PathType) -> np.ndarray:
     """Read HDF5 file of patch coordinates are return numpy array.
 

--- a/wsi_inference/modellib/run_inference.py
+++ b/wsi_inference/modellib/run_inference.py
@@ -241,7 +241,7 @@ def run_inference(
     results_dir: PathType,
     um_px: float,
     model_name: str,
-    weights: PathType,
+    weights: str,
     num_classes: int,
     patch_size: int,
     batch_size: int = 32,
@@ -266,8 +266,8 @@ def run_inference(
         value is used to resize the patches to their desired spacing.
     model_name : str
         Name of the model to create.
-    weights : str or pathlib.Path
-        Path to the weights for the model.
+    weights : str
+        Name of the weights to use.
     num_classes : int
         The number of classes the model outputs.
     patch_size : int
@@ -310,9 +310,7 @@ def run_inference(
             f"could not find patch hdf5 files: {patch_paths_notfound}"
         )
 
-    model = models.create_model(
-        model_name, num_classes=num_classes, state_dict_path=weights
-    )
+    model = models.create_model(model_name, num_classes=num_classes, weights=weights)
 
     return run_inference_on_slides(
         wsi_paths=wsi_paths,

--- a/wsi_inference/modellib/transforms.py
+++ b/wsi_inference/modellib/transforms.py
@@ -1,0 +1,62 @@
+"""PyTorch image classification transform.
+
+From
+https://github.com/pytorch/vision/blob/528651a031a08f9f97cc75bd619a326387708219/torchvision/transforms/_presets.py#L1
+"""
+
+from typing import Tuple
+from typing import Union
+
+from PIL import Image
+import torch
+from torchvision.transforms import functional as F
+
+# Get the interpolation mode while catering to older (and newer) versions of
+# torchvision and PIL.
+if hasattr(F, "InterpolationMode"):
+    BICUBIC = F.InterpolationMode.BICUBIC
+    BILINEAR = F.InterpolationMode.BILINEAR
+    LINEAR = F.InterpolationMode.BILINEAR
+    NEAREST = F.InterpolationMode.NEAREST
+elif hasattr(Image, "Resampling"):
+    BICUBIC = Image.Resampling.BICUBIC
+    BILINEAR = Image.Resampling.BILINEAR
+    LINEAR = Image.Resampling.BILINEAR
+    NEAREST = Image.Resampling.NEAREST
+else:
+    BICUBIC = Image.BICUBIC
+    BILINEAR = Image.BILINEAR
+    NEAREST = Image.NEAREST
+    LINEAR = Image.LINEAR
+
+
+class PatchClassification(torch.nn.Module):
+    def __init__(
+        self,
+        *,
+        resize_size: int,
+        mean: Tuple[float, float, float],
+        std: Tuple[float, float, float],
+        interpolation=BILINEAR,
+    ) -> None:
+        super().__init__()
+        self.resize_size = resize_size
+        self.mean = list(mean)
+        self.std = list(std)
+        self.interpolation = interpolation
+
+    def __repr__(self):
+        return (
+            f"PatchClassification(resize_size={self.resize_size}, mean={self.mean},"
+            f" std={self.std}, interpolation={self.interpolation})"
+        )
+
+    def forward(self, img: Union[Image.Image, torch.Tensor]) -> torch.Tensor:
+        img = F.resize(
+            img, [self.resize_size, self.resize_size], interpolation=self.interpolation
+        )
+        if not isinstance(img, torch.Tensor):
+            img = F.pil_to_tensor(img)
+        img = F.convert_image_dtype(img, torch.float)
+        img = F.normalize(img, mean=self.mean, std=self.std)
+        return img

--- a/wsi_inference/patchlib/create_patches_fp.py
+++ b/wsi_inference/patchlib/create_patches_fp.py
@@ -326,10 +326,10 @@ def seg_and_patch(
 
 def create_patches(
     source: str,
-    step_size: int,
     patch_size: int,
     patch_spacing: float,
     save_dir: str,
+    step_size: int = None,
     patch: bool = True,
     seg: bool = True,
     stitch: bool = True,

--- a/wsi_inference/patchlib/create_patches_fp.py
+++ b/wsi_inference/patchlib/create_patches_fp.py
@@ -235,9 +235,8 @@ def seg_and_patch(
         w, h = WSI_object.level_dim[current_seg_params["seg_level"]]
         if w * h > 1e8:
             print(
-                "level_dim {} x {} is likely too large for successful segmentation, aborting".format(
-                    w, h
-                )
+                "level_dim {} x {} is likely too large for successful segmentation,"
+                " aborting".format(w, h)
             )
             df.loc[idx, "status"] = "failed_seg"
             continue
@@ -325,71 +324,37 @@ def seg_and_patch(
     return seg_times, patch_times
 
 
-parser = argparse.ArgumentParser(description="seg and patch")
-parser.add_argument(
-    "--source",
-    type=str,
-    required=True,
-    help="path to folder containing raw wsi image files",
-)
-parser.add_argument("--step_size", type=int, default=None, help="step_size")
-parser.add_argument("--patch_size", type=int, required=True, help="patch_size")
-parser.add_argument("--patch", default=False, action="store_true")
-parser.add_argument("--seg", default=False, action="store_true")
-parser.add_argument("--stitch", default=False, action="store_true")
-parser.add_argument("--no_auto_skip", default=True, action="store_false")
-parser.add_argument(
-    "--save_dir", type=str, required=True, help="directory to save processed data"
-)
-parser.add_argument(
-    "--preset",
-    default=None,
-    type=str,
-    help="predefined profile of default segmentation and filter parameters (.csv)",
-)
-# parser.add_argument(
-#     "--patch_level", type=int, default=0, help="downsample level at which to patch"
-# )
-parser.add_argument(
-    "--process_list",
-    type=str,
-    default=None,
-    help="name of list of images to process with parameters (.csv)",
-)
-parser.add_argument(
-    "--patch_spacing",
-    type=float,
-    required=True,
-    help="Patch spacing in micrometers per pixel.",
-)
+def create_patches(
+    source: str,
+    step_size: int,
+    patch_size: int,
+    patch_spacing: float,
+    save_dir: str,
+    patch: bool = True,
+    seg: bool = True,
+    stitch: bool = True,
+    no_auto_skip: bool = True,
+    preset=None,
+    process_list=None,
+):
+    patch_save_dir = os.path.join(save_dir, "patches")
+    mask_save_dir = os.path.join(save_dir, "masks")
+    stitch_save_dir = os.path.join(save_dir, "stitches")
 
-
-def cli():
-    print("create_patches_fp.py  Copyright (C) 2022  Mahmood Lab")
-    print("This program comes with ABSOLUTELY NO WARRANTY.")
-    print("This is free software, and you are welcome to redistribute it")
-    print("under certain conditions.")
-
-    args = parser.parse_args()
-
-    patch_save_dir = os.path.join(args.save_dir, "patches")
-    mask_save_dir = os.path.join(args.save_dir, "masks")
-    stitch_save_dir = os.path.join(args.save_dir, "stitches")
-
-    if args.process_list:
-        process_list = os.path.join(args.save_dir, args.process_list)
+    if process_list:
+        process_list = os.path.join(save_dir, process_list)
 
     else:
         process_list = None
 
-    print("source: ", args.source)
+    print("source: ", source)
     print("patch_save_dir: ", patch_save_dir)
     print("mask_save_dir: ", mask_save_dir)
     print("stitch_save_dir: ", stitch_save_dir)
 
     directories = {
-        "source": args.source,
-        "save_dir": args.save_dir,
+        "source": source,
+        "save_dir": save_dir,
         "patch_save_dir": patch_save_dir,
         "mask_save_dir": mask_save_dir,
         "stitch_save_dir": stitch_save_dir,
@@ -413,8 +378,8 @@ def cli():
     vis_params = {"vis_level": -1, "line_thickness": 250}
     patch_params = {"use_padding": True, "contour_fn": "four_pt"}
 
-    if args.preset:
-        preset_df = pd.read_csv(_script_path / "presets" / args.preset)
+    if preset:
+        preset_df = pd.read_csv(_script_path / "presets" / preset)
         for key in seg_params.keys():
             seg_params[key] = preset_df.loc[0, key]
 
@@ -439,15 +404,73 @@ def cli():
     seg_and_patch(
         **directories,
         **parameters,
-        patch_size=args.patch_size,
-        step_size=args.step_size,
-        seg=args.seg,
+        patch_size=patch_size,
+        step_size=step_size,
+        seg=seg,
         use_default_params=False,
         save_mask=True,
-        stitch=args.stitch,
+        stitch=stitch,
         patch_level=0,  # args.patch_level,
-        patch=args.patch,
+        patch=patch,
         process_list=process_list,
-        auto_skip=args.no_auto_skip,
+        auto_skip=no_auto_skip,
+        patch_spacing=patch_spacing,
+    )
+
+
+def cli():
+    print("create_patches_fp.py  Copyright (C) 2022  Mahmood Lab")
+    print("This program comes with ABSOLUTELY NO WARRANTY.")
+    print("This is free software, and you are welcome to redistribute it")
+    print("under certain conditions.")
+
+    parser = argparse.ArgumentParser(description="seg and patch")
+    parser.add_argument(
+        "--source",
+        type=str,
+        required=True,
+        help="path to folder containing raw wsi image files",
+    )
+    parser.add_argument("--step_size", type=int, default=None, help="step_size")
+    parser.add_argument("--patch_size", type=int, required=True, help="patch_size")
+    parser.add_argument("--patch", default=False, action="store_true")
+    parser.add_argument("--seg", default=False, action="store_true")
+    parser.add_argument("--stitch", default=False, action="store_true")
+    parser.add_argument("--no_auto_skip", default=True, action="store_false")
+    parser.add_argument(
+        "--save_dir", type=str, required=True, help="directory to save processed data"
+    )
+    parser.add_argument(
+        "--preset",
+        default=None,
+        type=str,
+        help="predefined profile of default segmentation and filter parameters (.csv)",
+    )
+    parser.add_argument(
+        "--process_list",
+        type=str,
+        default=None,
+        help="name of list of images to process with parameters (.csv)",
+    )
+    parser.add_argument(
+        "--patch_spacing",
+        type=float,
+        required=True,
+        help="Patch spacing in micrometers per pixel.",
+    )
+
+    args = parser.parse_args()
+
+    create_patches(
+        source=args.source,
+        step_size=args.step_size,
+        patch_size=args.patch_size,
         patch_spacing=args.patch_spacing,
+        save_dir=args.save_dir,
+        patch=args.patch,
+        seg=args.seg,
+        stitch=args.stitch,
+        no_auto_skip=args.no_auto_skip,
+        preset=args.preset,
+        process_list=args.process_list,
     )


### PR DESCRIPTION
I have uploaded the model weights to stony brook's box service. this pull request adds lazy downloading of model weights. the weights of the model are downloaded if a user requests them (similar to the behavior in `torchvision.models` and `timm`). 

also adds a functional interface to the patching command (no more subprocess in the main cli)

improve error messages (particularly if a GPU is not available)

closes #9 