### PR TITLE
add conversion script to sbu bmi + support multires tiff + add dense grid prediction

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,32 @@ are able to load labels in GeoJSON format.
 wsi_convert_csv_to_geojson --class-name tumor results/model-outputs/CMU-1.csv CMU-1.json
 ```
 
+## Convert to Stony Brook QuIP format
+
+# Converting
+
+This code assumes one is working with TCGA slides, where the first 12 characters represent
+the subject ID and the first 23 represent the case ID.
+
+```bash
+mkdir -p model-outputs-sbubmi
+for filename in model-outputs/*; do
+    filename=$(basename $filename .csv)
+    subjectID=${filename::12}
+    caseID=${filename::23}
+    echo "Subject ID $subjectID"
+    echo "Case ID $caseID"
+    wsi_convert_csv_to_sbubmi \
+        --output-jsonl model-outputs-sbubmi/${filename}.json \
+        --output-table model-outputs-sbubmi/${filename}.txt \
+        --slide ../slides/${filename}.svs \
+        --subject-id $subjectID \
+        --case-id $caseID \
+        --class-name tumor model-outputs/${filename}.csv
+done
+```
+
+
 
 # Convert original models to newer PyTorch format
 

--- a/README.md
+++ b/README.md
@@ -179,8 +179,6 @@ wsi_convert_csv_to_geojson --class-name tumor results/model-outputs/CMU-1.csv CM
 
 ## Convert to Stony Brook QuIP format
 
-# Converting
-
 This code assumes one is working with TCGA slides, where the first 12 characters represent
 the subject ID and the first 23 represent the case ID.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,9 +35,8 @@ install_requires =
     # See https://pytorch.org/get-started/locally/.
     click>=8.0,<9
     h5py
-    # The patching module uses OpenSlide so we restrict ourselves to image formats
-    # compatible with OpenSlide.
-    large-image[openslide]>=1.8.0
+    # OpenSlide and TIFF readers should handle all images we will encounter.
+    large-image[openslide,tiff]>=1.8.0
     numpy
     opencv-python-headless>=4.0.0
     pandas

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ console_scripts =
     wsi_create_patches = wsi_inference.patchlib.create_patches_fp:cli
     wsi_run = wsi_inference.main:cli
     wsi_convert_csv_to_geojson = wsi_inference.convert_csv_to_geojson:cli
+    wsi_convert_csv_to_sbubmi = wsi_inference.convert_csv_to_sbubmi:cli
 
 [options.package_data]
 wsi_inference =

--- a/wsi_inference/convert_csv_to_sbubmi.py
+++ b/wsi_inference/convert_csv_to_sbubmi.py
@@ -150,13 +150,13 @@ def _version() -> str:
 @click.command()
 @click.argument("input", type=click.Path(exists=True, dir_okay=False, path_type=Path))
 @click.option(
-    "--output_jsonl",
+    "--output-jsonl",
     required=True,
     type=click.Path(dir_okay=False, exists=False, writable=True, path_type=Path),
     help="Path to write the JSON file (.json) file.",
 )
 @click.option(
-    "--output_table",
+    "--output-table",
     required=True,
     type=click.Path(dir_okay=False, exists=False, writable=True, path_type=Path),
     help="Path to write the text (.txt) file.",

--- a/wsi_inference/convert_csv_to_sbubmi.py
+++ b/wsi_inference/convert_csv_to_sbubmi.py
@@ -216,6 +216,7 @@ def cli(
         ts: large_image.tilesource.TileSource = large_image.getTileSource(slide)
         slide_width = ts.getMetadata()["sizeX"]
         slide_height = ts.getMetadata()["sizeY"]
+    print(f"Slide dimensions: {slide_width} x {slide_height} (width x height)")
 
     write_heatmap_json_like(
         input=input,

--- a/wsi_inference/convert_csv_to_sbubmi.py
+++ b/wsi_inference/convert_csv_to_sbubmi.py
@@ -91,7 +91,7 @@ def _row_to_heatmap_row(
                 "heatname_array": ["tumor", "necrosis"],
                 "weight_array": ["0.5", "0.5"],
             },
-            "metric_value": 0.0,
+            "metric_value": class_probability,
             "metric_type": "tile_dice",
             "human_mark": -1,
         },

--- a/wsi_inference/convert_csv_to_sbubmi.py
+++ b/wsi_inference/convert_csv_to_sbubmi.py
@@ -1,0 +1,220 @@
+"""Convert CSV of model outputs to Stony Brook BMI formats.
+
+This creates a JSON-lines file and a space-delimited table.
+"""
+
+from datetime import datetime
+import json
+from pathlib import Path
+import time
+import typing
+
+import click
+import pandas as pd
+
+
+PathType = typing.Union[str, Path]
+
+
+def _box_to_polygon(
+    *, minx: float, miny: float, width: float, height: float
+) -> typing.List[typing.Tuple[float, float]]:
+    """Get coordinates of a box polygon."""
+    maxx = minx + width
+    maxy = miny + height
+    return [(maxx, miny), (maxx, maxy), (minx, maxy), (minx, miny), (maxx, miny)]
+
+
+def _get_timestamp() -> str:
+    dt = datetime.now().astimezone()
+    # 2022-08-29 13:46:28 EDT
+    return dt.strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
+def _row_to_heatmap_row(
+    row: pd.Series,
+    *,
+    class_name: str,
+    slide_width: int,
+    slide_height: int,
+    case_id: typing.Optional[str] = None,
+    subject_id: typing.Optional[str] = None,
+) -> typing.Dict:
+    minx, miny, width, height = row["minx"], row["miny"], row["width"], row["height"]
+    patch_area_base_pixels = width * height
+    # Scale the values to be a ratio of the whole slide dimensions.
+    minx = float(minx / slide_width)
+    miny = float(miny / slide_height)
+    width = float(width / slide_width)
+    height = float(height / slide_height)
+    maxx = minx + width
+    maxy = miny + height
+    coords = _box_to_polygon(minx=minx, miny=miny, width=width, height=height)
+
+    # Get the probabilites from the model.
+    if class_name not in row.index:
+        raise KeyError(f"class name not found in results: {class_name}")
+    class_probability: float = row[class_name]
+    d = {
+        "type": "Feature",
+        "parent_id": "self",
+        # This seems to be the only un-normalized value.
+        "footprint": patch_area_base_pixels,
+        "x": (minx + maxx) / 2,
+        "y": (miny + maxy) / 2,
+        "normalized": "true",
+        "object_type": "heatmap_multiple",
+        "bbox": [
+            minx / slide_width,
+            miny / slide_height,
+            maxx / slide_width,
+            maxy / slide_height,
+        ],
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [coords],
+        },
+        "properties": {
+            # TODO: what should metric_* be?
+            "metric_value": 0.0,
+            "metric_type": "tile_dice",
+            "human_mark": -1,
+            "multiheat_param": {
+                "human_weight": -1,
+                "weight_array": ["1.0"],
+                "heatname_array": [class_name],
+                "metric_array": [class_probability],
+            },
+        },
+        "provenance": {
+            "image": {
+                "case_id": case_id,
+                "subject_id": subject_id,
+            },
+            "analysis": {
+                "study_id": "brca",
+                "execution_id": "cancer-brca-high_res",
+                "source": "computer",
+                "computation": "heatmap",
+                "execution_date": _get_timestamp(),
+            },
+            "version": {},
+        },
+        # Epoch time in seconds.
+        "date": {"$date": int(time.time())},
+    }
+    return d
+
+
+def write_heatmap_json_like(
+    input: PathType,
+    output: PathType,
+    class_name: str,
+    slide_width: int,
+    slide_height: int,
+    case_id: typing.Optional[str] = None,
+    subject_id: typing.Optional[str] = None,
+) -> None:
+    df = pd.read_csv(input)
+    features = df.apply(
+        _row_to_heatmap_row,
+        axis=1,
+        class_name=class_name,
+        slide_width=slide_width,
+        slide_height=slide_height,
+        case_id=case_id,
+        subject_id=subject_id,
+    )
+    features = features.tolist()
+    features_json = (json.dumps(row) for row in features)
+    with open(output, "w") as f:
+        f.writelines(line + "\n" for line in features_json)
+
+
+def write_heatmap_txt(input: PathType, output: PathType, class_name: str):
+    def _apply_fn(row: pd.Series) -> str:
+        minx, miny, w, h = (row["minx"], row["miny"], row["width"], row["height"])
+        class_probability: float = row[class_name]
+        centerx = round(minx + (w / 2))
+        centery = round(miny + (h / 2))
+        return f"{centerx} {centery} {class_probability}"
+
+    df = pd.read_csv(input)
+    # Each line is "centerx centery probability" and coordinates are in base pixels.
+    lines: typing.List[str] = df.apply(_apply_fn, axis=1).tolist()
+    with open(output, "w") as f:
+        f.writelines(line + "\n" for line in lines)
+
+
+def _version() -> str:
+    """Closure to return version (avoid possibility of a circular import)."""
+    from . import __version__
+
+    return __version__
+
+
+@click.command()
+@click.argument("input", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument(
+    "output_jsonl",
+    type=click.Path(dir_okay=False, exists=False, writable=True, path_type=Path),
+)
+@click.argument(
+    "output_table",
+    type=click.Path(dir_okay=False, exists=False, writable=True, path_type=Path),
+)
+@click.option(
+    "--class-name",
+    required=True,
+    help="Name of the class to use for probability values.",
+)
+@click.option(
+    "--slide-width",
+    required=True,
+    type=int,
+    help="Width of the slide in pixels (highest mag)",
+)
+@click.option(
+    "--slide-height",
+    required=True,
+    type=int,
+    help="Height of the slide in pixels (highest mag)",
+)
+@click.option("--subject-id", default=None, help="Subject ID", show_default=True)
+@click.option("--case-id", default=None, help="Subject's case ID", show_default=True)
+@click.version_option(version=_version())
+def cli(
+    *,
+    input: Path,
+    output_jsonl: Path,
+    output_table: Path,
+    class_name: str,
+    slide_width: int,
+    slide_height: int,
+    subject_id: typing.Optional[str],
+    case_id: typing.Optional[str],
+):
+    """Convert CSV of patch predictions to a GeoJSON file.
+
+    GeoJSON files can be used with pathology viewers like QuPath.
+
+    INPUT           Path to input CSV
+
+    OUTPUT_JSONL    Path to output JSON lines file (with .jsonl extension)
+
+    OUTPUT_TABLE    Path to output table files (with .txt extension)
+    """
+    click.echo(f"Reading CSV: {input}")
+
+    write_heatmap_json_like(
+        input=input,
+        output=output_jsonl,
+        class_name=class_name,
+        slide_width=slide_width,
+        slide_height=slide_height,
+        case_id=case_id,
+        subject_id=subject_id,
+    )
+    click.secho(f"Saved JSON lines output to {output_jsonl}", fg="green")
+    write_heatmap_txt(input=input, output=output_table, class_name=class_name)
+    click.secho(f"Saved table output to {output_table}", fg="green")

--- a/wsi_inference/patchlib/create_dense_patch_grid.py
+++ b/wsi_inference/patchlib/create_dense_patch_grid.py
@@ -1,0 +1,66 @@
+"""Create a dense grid of patch coordinates. This does *not* create a tissue mask."""
+
+import itertools
+from pathlib import Path
+from typing import Tuple
+
+import h5py
+import large_image
+import numpy as np
+
+
+def _get_dense_grid(
+    slide, orig_patch_size: int, patch_spacing_um_px: float
+) -> Tuple[np.ndarray, int]:
+    ts = large_image.getTileSource(slide)
+    patch_spacing_mm_px = patch_spacing_um_px / 1000
+    patch_size = orig_patch_size * patch_spacing_mm_px / ts.getMetadata()["mm_x"]
+    patch_size = round(patch_size)
+    step_size = patch_size  # non-overlapping patches
+    cols = ts.getMetadata()["sizeX"]
+    rows = ts.getMetadata()["sizeY"]
+    xs = range(0, cols, step_size)
+    ys = range(0, rows, step_size)
+    # List of (x, y) coordinates.
+    return np.asarray(list(itertools.product(xs, ys))), patch_size
+
+
+def create_grid_and_save(
+    slide, results_dir, orig_patch_size: int, patch_spacing_um_px: float
+):
+    """Create dense grid of (x,y) coordinates and save to HDF5.
+
+    This is similar to the CLAM coordinate code but does not use a tissue mask.
+    """
+    slide = Path(slide)
+    results_dir = Path(results_dir)
+    hdf5_path = results_dir / "patches" / f"{slide.stem}.h5"
+    hdf5_path.parent.mkdir(exist_ok=True)
+    coords, patch_size = _get_dense_grid(
+        slide=slide,
+        orig_patch_size=orig_patch_size,
+        patch_spacing_um_px=patch_spacing_um_px,
+    )
+    with h5py.File(hdf5_path, "w") as f:
+        dset = f.create_dataset("/coords", data=coords, compression="gzip")
+        dset.attrs["name"] = str(hdf5_path.stem)
+        dset.attrs["patch_level"] = 0
+        dset.attrs["patch_size"] = patch_size
+        dset.attrs["save_path"] = str(hdf5_path.parent)
+
+
+def create_grid_and_save_multi_slides(
+    wsi_dir, results_dir, orig_patch_size: int, patch_spacing_um_px: float
+):
+    wsi_dir = Path(wsi_dir)
+    slides = list(wsi_dir.glob("*"))
+    if not slides:
+        raise FileNotFoundError("no slides found")
+
+    for slide in slides:
+        create_grid_and_save(
+            slide=slide,
+            results_dir=results_dir,
+            orig_patch_size=orig_patch_size,
+            patch_spacing_um_px=patch_spacing_um_px,
+        )

--- a/wsi_inference/patchlib/create_patches_fp.py
+++ b/wsi_inference/patchlib/create_patches_fp.py
@@ -19,6 +19,16 @@
 #   spacing. The patch coordinates are calculated at the base (highest) resolution.
 # - format code with black
 
+"""Create tissue mask and patch a whole slide image.
+Copyright (C) 2022  Mahmood Lab
+
+Modified by Jakub Kaczmarzyk.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+"""
 
 # internal imports
 from .wsi_core.WholeSlideImage import WholeSlideImage
@@ -34,6 +44,13 @@ import argparse
 import pandas as pd
 
 _script_path = pathlib.Path(__file__).resolve().parent
+
+
+def _version() -> str:
+    """Closure to get version without potential for circular imports."""
+    from .. import __version__
+
+    return __version__
 
 
 def stitching(file_path, wsi_object, downscale=64):
@@ -419,12 +436,7 @@ def create_patches(
 
 
 def cli():
-    print("create_patches_fp.py  Copyright (C) 2022  Mahmood Lab")
-    print("This program comes with ABSOLUTELY NO WARRANTY.")
-    print("This is free software, and you are welcome to redistribute it")
-    print("under certain conditions.")
-
-    parser = argparse.ArgumentParser(description="seg and patch")
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--source",
         type=str,
@@ -458,8 +470,14 @@ def cli():
         required=True,
         help="Patch spacing in micrometers per pixel.",
     )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {_version()}")
 
     args = parser.parse_args()
+
+    print("create_patches_fp.py  Copyright (C) 2022  Mahmood Lab")
+    print("This program comes with ABSOLUTELY NO WARRANTY.")
+    print("This is free software, and you are welcome to redistribute it")
+    print("under certain conditions.")
 
     create_patches(
         source=args.source,


### PR DESCRIPTION
this pull request adds:
- `wsi_convert_csv_to_sbubmi` command line program to convert the output to a format used by stony brook biomedical informatics.
- large_image tiff source to the dependencies to read multi-scale tiff images.
- add prediction on a dense grid. in other words, run model inference on all patches of an image (without the creation of a tissue mask).