### PR TITLE
FIX mpp for TCGA BRCA v1 models

### DIFF
--- a/wsi_inference/modellib/models.py
+++ b/wsi_inference/modellib/models.py
@@ -67,7 +67,7 @@ WEIGHTS: Dict[str, Dict[str, Weights]] = {
                 std=(0.5, 0.5, 0.5),
             ),
             patch_size_pixels=350,
-            spacing_um_px=88 / 350,
+            spacing_um_px=0.25,
             class_names=["notumor", "tumor"],
             metadata={"patch-size": "350 pixels (88 microns)."},
         ),
@@ -83,7 +83,7 @@ WEIGHTS: Dict[str, Dict[str, Weights]] = {
                 std=(0.1120, 0.1459, 0.1089),
             ),
             patch_size_pixels=350,
-            spacing_um_px=88 / 350,
+            spacing_um_px=0.25,
             class_names=["notumor", "tumor"],
             metadata={"patch-size": "350 pixels (88 microns)."},
         )
@@ -99,7 +99,7 @@ WEIGHTS: Dict[str, Dict[str, Weights]] = {
                 std=(0.1120, 0.1459, 0.1089),
             ),
             patch_size_pixels=350,
-            spacing_um_px=88 / 350,
+            spacing_um_px=0.25,
             class_names=["notumor", "tumor"],
             metadata={"patch-size": "350 pixels (88 microns)."},
         )

--- a/wsi_inference/modellib/models.py
+++ b/wsi_inference/modellib/models.py
@@ -69,7 +69,7 @@ WEIGHTS: Dict[str, Dict[str, Weights]] = {
             patch_size_pixels=350,
             spacing_um_px=0.25,
             class_names=["notumor", "tumor"],
-            metadata={"patch-size": "350 pixels (88 microns)."},
+            metadata={"patch-size": "350 pixels (87.5 microns)"},
         ),
     },
     "resnet34": {
@@ -85,7 +85,7 @@ WEIGHTS: Dict[str, Dict[str, Weights]] = {
             patch_size_pixels=350,
             spacing_um_px=0.25,
             class_names=["notumor", "tumor"],
-            metadata={"patch-size": "350 pixels (88 microns)."},
+            metadata={"patch-size": "350 pixels (87.5 microns)"},
         )
     },
     "vgg16_modified": {
@@ -101,7 +101,7 @@ WEIGHTS: Dict[str, Dict[str, Weights]] = {
             patch_size_pixels=350,
             spacing_um_px=0.25,
             class_names=["notumor", "tumor"],
-            metadata={"patch-size": "350 pixels (88 microns)."},
+            metadata={"patch-size": "350 pixels (87.5 microns)"},
         )
     },
 }


### PR DESCRIPTION
Use 350 px patches at 0.25 mpp. Patches are 87.5 um. Fixes #18 