### PR TITLE
FIX: skip slides without spacing information

### DIFF
--- a/wsi_inference/modellib/run_inference.py
+++ b/wsi_inference/modellib/run_inference.py
@@ -7,6 +7,7 @@ From the original paper (https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7369575/):
 
 import pathlib
 import typing
+import warnings
 
 import h5py
 import large_image
@@ -45,7 +46,7 @@ class PatchDirectoryNotFound(FileNotFoundError):
     ...
 
 
-class PatchFilesNotFound(FileNotFoundError):
+class PatchFilesNotFoundWarning(UserWarning):
     ...
 
 
@@ -203,7 +204,11 @@ def run_inference(
     patch_paths = [patch_dir / p.with_suffix(".h5").name for p in wsi_paths]
     patch_paths_notfound = [p for p in patch_paths if not p.exists()]
     if patch_paths_notfound:
-        raise PatchFilesNotFound(patch_paths_notfound)
+        warnings.warn(
+            "Patch extraction seems to have failed for the following slides:"
+            + " ".join(str(p) for p in patch_paths_notfound),
+            category=PatchFilesNotFoundWarning,
+        )
 
     if weights.model is None:
         raise RuntimeError("model cannot be None in the weights object")

--- a/wsi_inference/patchlib/create_patches_fp.py
+++ b/wsi_inference/patchlib/create_patches_fp.py
@@ -294,6 +294,7 @@ def seg_and_patch(
                     print("SKIPPING this slide because I cannot find the spacing!")
                     print(full_path)
                     print("!" * 40)
+                    continue
                 patch_mm = patch_spacing / 1000  # convert micrometer to millimeter.
                 patch_size = orig_patch_size * patch_mm / ts.getMetadata()["mm_x"]
                 patch_size = round(patch_size)

--- a/wsi_inference/patchlib/create_patches_fp.py
+++ b/wsi_inference/patchlib/create_patches_fp.py
@@ -289,6 +289,11 @@ def seg_and_patch(
                 del orig_max, Image
 
                 ts = large_image.getTileSource(full_path)
+                if "mm_x" not in ts.getMetadata().keys():
+                    print("!" * 40)
+                    print("SKIPPING this slide because I cannot find the spacing!")
+                    print(full_path)
+                    print("!" * 40)
                 patch_mm = patch_spacing / 1000  # convert micrometer to millimeter.
                 patch_size = orig_patch_size * patch_mm / ts.getMetadata()["mm_x"]
                 patch_size = round(patch_size)

--- a/wsi_inference/patchlib/create_patches_fp.py
+++ b/wsi_inference/patchlib/create_patches_fp.py
@@ -289,7 +289,7 @@ def seg_and_patch(
                 del orig_max, Image
 
                 ts = large_image.getTileSource(full_path)
-                if "mm_x" not in ts.getMetadata().keys():
+                if ts.getMetadata()["mm_x"] is None:
                     print("!" * 40)
                     print("SKIPPING this slide because I cannot find the spacing!")
                     print(full_path)


### PR DESCRIPTION
We cannot work with slides that are missing spacing information, so let's skip them for now. In the future, maybe we can add a command line flag to provide spacing.