### PR TITLE
skip slides with missing patch hdf5 files

### DIFF
--- a/wsi_inference/modellib/run_inference.py
+++ b/wsi_inference/modellib/run_inference.py
@@ -206,7 +206,7 @@ def run_inference(
     if patch_paths_notfound:
         warnings.warn(
             "Patch extraction seems to have failed for the following slides:"
-            + " ".join(str(p) for p in patch_paths_notfound),
+            + " ".join(str(p.stem) for p in patch_paths_notfound),
             category=PatchFilesNotFoundWarning,
         )
 
@@ -235,6 +235,10 @@ def run_inference(
         if slide_csv.exists():
             print("Output CSV exists... skipping.")
             print(slide_csv)
+            continue
+
+        if not patch_path.exists():
+            print(f"Skipping because patch file not found: {patch_path}")
             continue
 
         dset = WholeSlideImagePatches(


### PR DESCRIPTION
It is possible for patching to fail, for example because the pixel spacing is not present in the slide file. This commit modifies the inference loop to skip files that are missing their patch hdf5 files.

Fixes #24 