### PR TITLE
ADD: paad model

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,3 +246,8 @@ orig_model = torch.load(model_path, map_location="cpu")
 state_dict = orig_model["model"].module.state_dict()
 torch.save(state_dict, "vgg16-modified-new.pt")
 ```
+
+
+## Preactivation ResNet34
+
+The model was downloaded from SBU's PAAD detection [repository](https://github.com/SBU-BMI/quip_paad_cancer_detection/blob/master/models_cnn/paad_baseline_preact-res34_train_TCGA_ensemble_epoch_7_auc_0.8595125864960883). The "net" value of the state dict contained the model weights.

--- a/wsi_inference/modellib/models.py
+++ b/wsi_inference/modellib/models.py
@@ -154,6 +154,22 @@ WEIGHTS: Dict[str, Dict[str, Weights]] = {
             metadata={},
         ),
     },
+    "resnet34_preact": {
+        "TCGA-PAAD-v1": Weights(
+            url="https://stonybrookmedicine.box.com/shared/static/sol1h9aqrh8lynzc6kidw1lsoeks20hh.pt",  # noqa
+            file_name="preactresnet34-paad-20210101-7892b41f.pt",
+            num_classes=1,
+            transform=PatchClassification(
+                resize_size=224,
+                mean=(0.7238, 0.5716, 0.6779),
+                std=(0.1120, 0.1459, 0.1089),
+            ),
+            patch_size_pixels=350,
+            spacing_um_px=None,  # TODO: what is the correct value?
+            class_names=["tumor"],
+            metadata={},
+        ),
+    },
     "vgg16_modified": {
         "TCGA-BRCA-v1": Weights(
             url="https://stonybrookmedicine.box.com/shared/static/197s56yvcrdpan7eu5tq8d4gxvq3xded.pt",  # noqa

--- a/wsi_inference/modellib/models.py
+++ b/wsi_inference/modellib/models.py
@@ -20,6 +20,7 @@ import torchvision
 
 from .inceptionv4 import inceptionv4 as _inceptionv4
 from .inceptionv4_no_batchnorm import inceptionv4 as _inceptionv4_no_bn
+from .resnet_preact import resnet34_preact as _resnet34_preact
 from .transforms import PatchClassification
 
 PathType = Union[str, pathlib.Path]
@@ -197,7 +198,7 @@ def _load_state_into_model(model: torch.nn.Module, weights: Weights):
     return model
 
 
-def inceptionv4(weights: str = "TCGA-BRCA-v1") -> Weights:
+def inceptionv4(weights: str) -> Weights:
     """Create InceptionV4 model."""
     weights_obj = _get_model_weights("inceptionv4", weights=weights)
     if weights == "TCGA-TILs-v1":
@@ -210,7 +211,7 @@ def inceptionv4(weights: str = "TCGA-BRCA-v1") -> Weights:
     return weights_obj
 
 
-def resnet34(weights: str = "TCGA-BRCA-v1") -> Weights:
+def resnet34(weights: str) -> Weights:
     """Create ResNet34 model."""
     weights_obj = _get_model_weights("resnet34", weights=weights)
     model = torchvision.models.resnet34()
@@ -220,7 +221,17 @@ def resnet34(weights: str = "TCGA-BRCA-v1") -> Weights:
     return weights_obj
 
 
-def vgg16(weights="TCGA-TILs-v1") -> Weights:
+def resnet34_preact(weights: str) -> Weights:
+    """Create ResNet34-Preact model."""
+    weights_obj = _get_model_weights("resnet34", weights=weights)
+    model = _resnet34_preact()
+    model.linear = torch.nn.Linear(model.linear.in_features, weights_obj.num_classes)
+    model = _load_state_into_model(model=model, weights=weights_obj)
+    weights_obj.model = model
+    return weights_obj
+
+
+def vgg16(weights: str) -> Weights:
     """Create VGG16 model."""
     weights_obj = _get_model_weights("vgg16", weights=weights)
     model = torchvision.models.vgg16()
@@ -232,7 +243,7 @@ def vgg16(weights="TCGA-TILs-v1") -> Weights:
     return weights_obj
 
 
-def vgg16_modified(weights="TCGA-BRCA-v1") -> Weights:
+def vgg16_modified(weights: str) -> Weights:
     """Create modified VGG16 model.
 
     The classifier of this model is
@@ -254,6 +265,7 @@ def vgg16_modified(weights="TCGA-BRCA-v1") -> Weights:
 MODELS = dict(
     inceptionv4=inceptionv4,
     resnet34=resnet34,
+    resnet34_preact=resnet34_preact,
     vgg16=vgg16,
     vgg16_modified=vgg16_modified,
 )

--- a/wsi_inference/modellib/models.py
+++ b/wsi_inference/modellib/models.py
@@ -242,7 +242,7 @@ def resnet34(weights: str) -> Weights:
 
 def resnet34_preact(weights: str) -> Weights:
     """Create ResNet34-Preact model."""
-    weights_obj = _get_model_weights("resnet34", weights=weights)
+    weights_obj = _get_model_weights("resnet34_preact", weights=weights)
     model = _resnet34_preact()
     model.linear = torch.nn.Linear(model.linear.in_features, weights_obj.num_classes)
     model = _load_state_into_model(model=model, weights=weights_obj)

--- a/wsi_inference/modellib/models.py
+++ b/wsi_inference/modellib/models.py
@@ -165,7 +165,10 @@ WEIGHTS: Dict[str, Dict[str, Weights]] = {
                 std=(0.1120, 0.1459, 0.1089),
             ),
             patch_size_pixels=350,
-            spacing_um_px=None,  # TODO: what is the correct value?
+            # Patches are 525.1106 microns.
+            # Patch of 2078 pixels @ 0.2527 mpp is 350 pixels at our target spacing.
+            # (2078 * 0.2527) / 350
+            spacing_um_px=1.500316,
             class_names=["tumor"],
             metadata={},
         ),

--- a/wsi_inference/modellib/resnet_preact.py
+++ b/wsi_inference/modellib/resnet_preact.py
@@ -111,7 +111,6 @@ class PreActResNet(nn.Module):
         out = F.avg_pool2d(out, out.size(2))
         out = out.view(out.size(0), -1)
         out = self.linear(out)
-        out = out.squeeze()
         return out
 
 

--- a/wsi_inference/modellib/resnet_preact.py
+++ b/wsi_inference/modellib/resnet_preact.py
@@ -10,7 +10,7 @@ class PreActBlock(nn.Module):
     expansion = 1
 
     def __init__(self, in_planes, planes, stride=1):
-        super(PreActBlock, self).__init__()
+        super().__init__()
         self.bn1 = nn.BatchNorm2d(in_planes)
         self.conv1 = nn.Conv2d(
             in_planes, planes, kernel_size=3, stride=stride, padding=1, bias=False
@@ -80,11 +80,13 @@ class PreActBottleneck(nn.Module):
 
 
 class PreActResNet(nn.Module):
-    def __init__(self, block, num_blocks, num_classes=10):
+    def __init__(self, block, num_blocks, num_classes=1):
         super(PreActResNet, self).__init__()
         self.in_planes = 64
 
-        self.conv1 = nn.Conv2d(3, 64, kernel_size=3, stride=1, padding=1, bias=False)
+        self.conv1 = nn.Conv2d(3, 64, kernel_size=7, stride=1, padding=1, bias=False)
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+
         self.layer1 = self._make_layer(block, 64, num_blocks[0], stride=1)
         self.layer2 = self._make_layer(block, 128, num_blocks[1], stride=2)
         self.layer3 = self._make_layer(block, 256, num_blocks[2], stride=2)
@@ -101,13 +103,15 @@ class PreActResNet(nn.Module):
 
     def forward(self, x):
         out = self.conv1(x)
+        out = self.maxpool(out)
         out = self.layer1(out)
         out = self.layer2(out)
         out = self.layer3(out)
         out = self.layer4(out)
-        out = F.avg_pool2d(out, 4)
+        out = F.avg_pool2d(out, out.size(2))
         out = out.view(out.size(0), -1)
         out = self.linear(out)
+        out = out.squeeze()
         return out
 
 

--- a/wsi_inference/modellib/resnet_preact.py
+++ b/wsi_inference/modellib/resnet_preact.py
@@ -1,0 +1,115 @@
+"""Pre-activation ResNet."""
+
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class PreActBlock(nn.Module):
+    """Pre-activation version of the BasicBlock."""
+
+    expansion = 1
+
+    def __init__(self, in_planes, planes, stride=1):
+        super(PreActBlock, self).__init__()
+        self.bn1 = nn.BatchNorm2d(in_planes)
+        self.conv1 = nn.Conv2d(
+            in_planes, planes, kernel_size=3, stride=stride, padding=1, bias=False
+        )
+        self.bn2 = nn.BatchNorm2d(planes)
+        self.conv2 = nn.Conv2d(
+            planes, planes, kernel_size=3, stride=1, padding=1, bias=False
+        )
+
+        if stride != 1 or in_planes != self.expansion * planes:
+            self.shortcut = nn.Sequential(
+                nn.Conv2d(
+                    in_planes,
+                    self.expansion * planes,
+                    kernel_size=1,
+                    stride=stride,
+                    bias=False,
+                )
+            )
+
+    def forward(self, x):
+        out = F.relu(self.bn1(x))
+        shortcut = self.shortcut(out) if hasattr(self, "shortcut") else x
+        out = self.conv1(out)
+        out = self.conv2(F.relu(self.bn2(out)))
+        out += shortcut
+        return out
+
+
+class PreActBottleneck(nn.Module):
+    """Pre-activation version of the original Bottleneck module."""
+
+    expansion = 4
+
+    def __init__(self, in_planes, planes, stride=1):
+        super(PreActBottleneck, self).__init__()
+        self.bn1 = nn.BatchNorm2d(in_planes)
+        self.conv1 = nn.Conv2d(in_planes, planes, kernel_size=1, bias=False)
+        self.bn2 = nn.BatchNorm2d(planes)
+        self.conv2 = nn.Conv2d(
+            planes, planes, kernel_size=3, stride=stride, padding=1, bias=False
+        )
+        self.bn3 = nn.BatchNorm2d(planes)
+        self.conv3 = nn.Conv2d(
+            planes, self.expansion * planes, kernel_size=1, bias=False
+        )
+
+        if stride != 1 or in_planes != self.expansion * planes:
+            self.shortcut = nn.Sequential(
+                nn.Conv2d(
+                    in_planes,
+                    self.expansion * planes,
+                    kernel_size=1,
+                    stride=stride,
+                    bias=False,
+                )
+            )
+
+    def forward(self, x):
+        out = F.relu(self.bn1(x))
+        shortcut = self.shortcut(out) if hasattr(self, "shortcut") else x
+        out = self.conv1(out)
+        out = self.conv2(F.relu(self.bn2(out)))
+        out = self.conv3(F.relu(self.bn3(out)))
+        out += shortcut
+        return out
+
+
+class PreActResNet(nn.Module):
+    def __init__(self, block, num_blocks, num_classes=10):
+        super(PreActResNet, self).__init__()
+        self.in_planes = 64
+
+        self.conv1 = nn.Conv2d(3, 64, kernel_size=3, stride=1, padding=1, bias=False)
+        self.layer1 = self._make_layer(block, 64, num_blocks[0], stride=1)
+        self.layer2 = self._make_layer(block, 128, num_blocks[1], stride=2)
+        self.layer3 = self._make_layer(block, 256, num_blocks[2], stride=2)
+        self.layer4 = self._make_layer(block, 512, num_blocks[3], stride=2)
+        self.linear = nn.Linear(512 * block.expansion, num_classes)
+
+    def _make_layer(self, block, planes, num_blocks, stride):
+        strides = [stride] + [1] * (num_blocks - 1)
+        layers = []
+        for stride in strides:
+            layers.append(block(self.in_planes, planes, stride))
+            self.in_planes = planes * block.expansion
+        return nn.Sequential(*layers)
+
+    def forward(self, x):
+        out = self.conv1(x)
+        out = self.layer1(out)
+        out = self.layer2(out)
+        out = self.layer3(out)
+        out = self.layer4(out)
+        out = F.avg_pool2d(out, 4)
+        out = out.view(out.size(0), -1)
+        out = self.linear(out)
+        return out
+
+
+def resnet34_preact():
+    return PreActResNet(PreActBlock, [3, 4, 6, 3])

--- a/wsi_inference/modellib/resnet_preact.py
+++ b/wsi_inference/modellib/resnet_preact.py
@@ -40,51 +40,12 @@ class PreActBlock(nn.Module):
         return out
 
 
-class PreActBottleneck(nn.Module):
-    """Pre-activation version of the original Bottleneck module."""
-
-    expansion = 4
-
-    def __init__(self, in_planes, planes, stride=1):
-        super(PreActBottleneck, self).__init__()
-        self.bn1 = nn.BatchNorm2d(in_planes)
-        self.conv1 = nn.Conv2d(in_planes, planes, kernel_size=1, bias=False)
-        self.bn2 = nn.BatchNorm2d(planes)
-        self.conv2 = nn.Conv2d(
-            planes, planes, kernel_size=3, stride=stride, padding=1, bias=False
-        )
-        self.bn3 = nn.BatchNorm2d(planes)
-        self.conv3 = nn.Conv2d(
-            planes, self.expansion * planes, kernel_size=1, bias=False
-        )
-
-        if stride != 1 or in_planes != self.expansion * planes:
-            self.shortcut = nn.Sequential(
-                nn.Conv2d(
-                    in_planes,
-                    self.expansion * planes,
-                    kernel_size=1,
-                    stride=stride,
-                    bias=False,
-                )
-            )
-
-    def forward(self, x):
-        out = F.relu(self.bn1(x))
-        shortcut = self.shortcut(out) if hasattr(self, "shortcut") else x
-        out = self.conv1(out)
-        out = self.conv2(F.relu(self.bn2(out)))
-        out = self.conv3(F.relu(self.bn3(out)))
-        out += shortcut
-        return out
-
-
 class PreActResNet(nn.Module):
     def __init__(self, block, num_blocks, num_classes=1):
         super(PreActResNet, self).__init__()
         self.in_planes = 64
 
-        self.conv1 = nn.Conv2d(3, 64, kernel_size=7, stride=1, padding=1, bias=False)
+        self.conv1 = nn.Conv2d(3, 64, kernel_size=7, stride=2, padding=3, bias=False)
         self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
 
         self.layer1 = self._make_layer(block, 64, num_blocks[0], stride=1)

--- a/wsi_inference/modellib/run_inference.py
+++ b/wsi_inference/modellib/run_inference.py
@@ -270,9 +270,11 @@ def run_inference(
             assert batch_imgs.shape[0] == batch_coords.shape[0], "length mismatch"
             with torch.no_grad():
                 logits: torch.Tensor = model(batch_imgs.to(device)).detach().cpu()
-            # probs has shape (batch_size, num_classes)
-            probs = torch.nn.functional.softmax(logits, dim=1)
-
+            # probs has shape (batch_size, num_classes) or (batch_size,)
+            if len(logits.shape) > 1 and logits.shape[1] > 1:
+                probs = torch.nn.functional.softmax(logits, dim=1)
+            else:
+                probs = torch.sigmoid(logits.squeeze(1))
             slide_coords.append(batch_coords.numpy())
             slide_probs.append(probs.numpy())
 


### PR DESCRIPTION
this PR 
- adds a model for detection of pancreatic adenocarcinoma. 
- adds support for 1-class model outputs, where sigmoid is used to convert logits to a probability distribution.
- implements preactivation resnet.
- removes the default weights for model loaders. now, weights need to be specified.

Closes #17 

Please see #17 for more information and a visualization of model outputs.

