### PR TITLE
FIX: make downloaded models readable by all users

### DIFF
--- a/dockerfiles/tils.dockerfile
+++ b/dockerfiles/tils.dockerfile
@@ -10,3 +10,5 @@ ENV WSIRUN_WEIGHTS="TCGA-TILs-v1"
 
 # Download the weights.
 RUN python -c "from wsi_inference.modellib import models; models.$WSIRUN_MODEL(\"$WSIRUN_WEIGHTS\")"
+# Downloaded models are mode 0600. Make them readable by all users.
+RUN chmod -R +r $TORCH_HOME/hub/checkpoints/

--- a/dockerfiles/tumor-brca.dockerfile
+++ b/dockerfiles/tumor-brca.dockerfile
@@ -10,3 +10,5 @@ ENV WSIRUN_WEIGHTS="TCGA-BRCA-v1"
 
 # Download the weights.
 RUN python -c "from wsi_inference.modellib import models; models.$WSIRUN_MODEL(\"$WSIRUN_WEIGHTS\")"
+# Downloaded models are mode 0600. Make them readable by all users.
+RUN chmod -R +r $TORCH_HOME/hub/checkpoints/

--- a/dockerfiles/tumor-luad.dockerfile
+++ b/dockerfiles/tumor-luad.dockerfile
@@ -10,3 +10,5 @@ ENV WSIRUN_WEIGHTS="TCGA-LUAD-v1"
 
 # Download the weights.
 RUN python -c "from wsi_inference.modellib import models; models.$WSIRUN_MODEL(\"$WSIRUN_WEIGHTS\")"
+# Downloaded models are mode 0600. Make them readable by all users.
+RUN chmod -R +r $TORCH_HOME/hub/checkpoints/

--- a/dockerfiles/tumor-paad.dockerfile
+++ b/dockerfiles/tumor-paad.dockerfile
@@ -10,3 +10,5 @@ ENV WSIRUN_WEIGHTS="TCGA-PAAD-v1"
 
 # Download the weights.
 RUN python -c "from wsi_inference.modellib import models; models.$WSIRUN_MODEL(\"$WSIRUN_WEIGHTS\")"
+# Downloaded models are mode 0600. Make them readable by all users.
+RUN chmod -R +r $TORCH_HOME/hub/checkpoints/

--- a/dockerfiles/tumor-prad.dockerfile
+++ b/dockerfiles/tumor-prad.dockerfile
@@ -10,3 +10,5 @@ ENV WSIRUN_WEIGHTS="TCGA-PRAD-v1"
 
 # Download the weights.
 RUN python -c "from wsi_inference.modellib import models; models.$WSIRUN_MODEL(\"$WSIRUN_WEIGHTS\")"
+# Downloaded models are mode 0600. Make them readable by all users.
+RUN chmod -R +r $TORCH_HOME/hub/checkpoints/


### PR DESCRIPTION
Downloaded models are made with mode 0600. This is because they start out as tempfile.NamedTemporaryFile objects, which are by default made with 0600 mode.