### PR TITLE
ENH: add center patch prediction

### DIFF
--- a/wsi_inference/main.py
+++ b/wsi_inference/main.py
@@ -203,6 +203,7 @@ def cli(
             save_dir=str(results_dir),
             patch_size=weights_obj.patch_size_pixels,
             patch_spacing=weights_obj.spacing_um_px,
+            step_size=weights_obj.center_square_output_pixels,
             seg=True,
             patch=True,
             preset="tcga.csv",

--- a/wsi_inference/modellib/models.py
+++ b/wsi_inference/modellib/models.py
@@ -127,9 +127,7 @@ WEIGHTS: Dict[str, Dict[str, Weights]] = {
             transform=PatchClassification(
                 resize_size=299, mean=(0.5, 0.5, 0.5), std=(0.5, 0.5, 0.5)
             ),
-            # 150x150 um2 for inference. The result is for 50x50 um2 center.
-            patch_size_pixels=300,
-            center_square_output_pixels=100,
+            patch_size_pixels=100,
             spacing_um_px=0.5,
             class_names=["notils", "tils"],
             metadata={

--- a/wsi_inference/patchlib/create_patches_fp.py
+++ b/wsi_inference/patchlib/create_patches_fp.py
@@ -162,6 +162,7 @@ def seg_and_patch(
     stitch_times = 0.0
 
     orig_patch_size = patch_size
+    orig_step_size = step_size
 
     for i in range(total):
         df.to_csv(os.path.join(save_dir, "process_list_autogen.csv"), index=False)
@@ -298,9 +299,16 @@ def seg_and_patch(
                 patch_mm = patch_spacing / 1000  # convert micrometer to millimeter.
                 patch_size = orig_patch_size * patch_mm / ts.getMetadata()["mm_x"]
                 patch_size = round(patch_size)
+
+                # Get the proper step size if it is defined.
+                if orig_step_size is not None:
+                    step_size = orig_step_size * patch_mm / ts.getMetadata()["mm_x"]
+                    step_size = round(step_size)
+
                 del ts
             # Use non-overlapping patches by default.
-            step_size = step_size or patch_size
+            if orig_step_size is None:
+                step_size = patch_size
             # ----------------------------------------------------------------------
 
             current_patch_params.update(


### PR DESCRIPTION
this adds functionality to predict on a patch and keep the model output for a central region of that patch. This is how model inference is done for the TIL models in https://doi.org/10.3389/fonc.2021.806603

fixes #33 