### PR TITLE
update model-specific docker image versions + fix _in_container + make --model required

### DIFF
--- a/dockerfiles/tils.dockerfile
+++ b/dockerfiles/tils.dockerfile
@@ -2,7 +2,7 @@
 #
 # Note about versioning: We should not use the 'latest' tag because it is a moving
 # target. We should prefer using a versioned release of the wsi_inference pipeline.
-FROM kaczmarj/patch-classification-pipeline:v0.2.0
+FROM kaczmarj/patch-classification-pipeline:v0.2.1
 
 # The CLI will use these env vars for model and weights.
 ENV WSIRUN_MODEL="inceptionv4"

--- a/dockerfiles/tumor-brca.dockerfile
+++ b/dockerfiles/tumor-brca.dockerfile
@@ -2,7 +2,7 @@
 #
 # Note about versioning: We should not use the 'latest' tag because it is a moving
 # target. We should prefer using a versioned release of the wsi_inference pipeline.
-FROM kaczmarj/patch-classification-pipeline:v0.2.0
+FROM kaczmarj/patch-classification-pipeline:v0.2.1
 
 # The CLI will use these env vars for model and weights.
 ENV WSIRUN_MODEL="resnet34"

--- a/dockerfiles/tumor-luad.dockerfile
+++ b/dockerfiles/tumor-luad.dockerfile
@@ -2,7 +2,7 @@
 #
 # Note about versioning: We should not use the 'latest' tag because it is a moving
 # target. We should prefer using a versioned release of the wsi_inference pipeline.
-FROM kaczmarj/patch-classification-pipeline:v0.2.0
+FROM kaczmarj/patch-classification-pipeline:v0.2.1
 
 # The CLI will use these env vars for model and weights.
 ENV WSIRUN_MODEL="resnet34"

--- a/dockerfiles/tumor-paad.dockerfile
+++ b/dockerfiles/tumor-paad.dockerfile
@@ -2,7 +2,7 @@
 #
 # Note about versioning: We should not use the 'latest' tag because it is a moving
 # target. We should prefer using a versioned release of the wsi_inference pipeline.
-FROM kaczmarj/patch-classification-pipeline:v0.2.0
+FROM kaczmarj/patch-classification-pipeline:v0.2.1
 
 # The CLI will use these env vars for model and weights.
 ENV WSIRUN_MODEL="resnet34_preact"

--- a/dockerfiles/tumor-prad.dockerfile
+++ b/dockerfiles/tumor-prad.dockerfile
@@ -2,7 +2,7 @@
 #
 # Note about versioning: We should not use the 'latest' tag because it is a moving
 # target. We should prefer using a versioned release of the wsi_inference pipeline.
-FROM kaczmarj/patch-classification-pipeline:v0.2.0
+FROM kaczmarj/patch-classification-pipeline:v0.2.1
 
 # The CLI will use these env vars for model and weights.
 ENV WSIRUN_MODEL="resnet34"

--- a/scripts/build_docker_images.sh
+++ b/scripts/build_docker_images.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Build all Docker images. This includes the main image and all app images.
+
+set -ex
+
+here=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $here/..
+
+usage="usage: $0 VERSION [PUSH_IMAGES]"
+
+if [ $# -eq 0 ]; then
+    echo "No arguments supplied"
+    exit 1
+fi
+
+if [ -z "$1" ]; then
+    echo "No version supplied"
+    echo $usage
+    exit 2
+fi
+
+# Version of the pipeline.
+version=$1
+
+# Main image.
+docker build -t kaczmarj/patch-classification-pipeline:$version .
+
+# TILs
+docker build -t kaczmarj/patch-classification-pipeline:$version-tils - < dockerfiles/tils.dockerfile
+
+# Tumor BRCA
+docker build -t kaczmarj/patch-classification-pipeline:$version-tumor-brca - < dockerfiles/tumor-brca.dockerfile
+
+# Tumor LUAD
+docker build -t kaczmarj/patch-classification-pipeline:$version-tumor-luad - < dockerfiles/tumor-luad.dockerfile
+
+# Tumor PAAD
+docker build -t kaczmarj/patch-classification-pipeline:$version-tumor-paad - < dockerfiles/tumor-paad.dockerfile
+
+# Tumor PRAD
+docker build -t kaczmarj/patch-classification-pipeline:$version-tumor-prad - < dockerfiles/tumor-prad.dockerfile
+
+# Push images.
+push_images="${2:-0}"
+if [ $push_images -eq 0 ]; then
+    echo "Not pushing images. Pass a 1 to the script to push images."
+else
+    echo "Pushing images."
+    docker push kaczmarj/patch-classification-pipeline:$version
+    docker push kaczmarj/patch-classification-pipeline:$version-tils
+    docker push kaczmarj/patch-classification-pipeline:$version-tumor-brca
+    docker push kaczmarj/patch-classification-pipeline:$version-tumor-luad
+    docker push kaczmarj/patch-classification-pipeline:$version-tumor-paad
+    docker push kaczmarj/patch-classification-pipeline:$version-tumor-prad
+fi

--- a/wsi_inference/main.py
+++ b/wsi_inference/main.py
@@ -201,7 +201,7 @@ def _get_info_for_save(weights: models.Weights):
 @click.option(
     "--weights",
     type=str,
-    default="TCGA-BRCA-v1",
+    required=True,
     show_default=True,
     help="Weights to use for the model.",
 )

--- a/wsi_inference/main.py
+++ b/wsi_inference/main.py
@@ -23,7 +23,11 @@ PathType = typing.Union[str, pathlib.Path]
 def _inside_container() -> str:
     if pathlib.Path("/.dockerenv").exists():
         return "yes, docker"
-    elif pathlib.Path("/singularity.d").exists():
+    elif (
+        pathlib.Path("/singularity").exists()
+        or pathlib.Path("/singularity.d").exists()
+        or pathlib.Path("/.singularity.d").exists()
+    ):
         # TODO: apptainer might change the name of this directory.
         return "yes, apptainer/singularity"
     return "no"


### PR DESCRIPTION
- set the version of the base image to `v0.2.1`.
- fix the function `_in_container` to properly detect whether the code is running inside a singularity / apptainer container.
- make `--model` a required argument in `wsi_run`.