### PR TITLE
ENH: use yaml config files to define models

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,8 @@ install_requires =
     opencv-python-headless>=4.0.0
     pandas
     pillow
+    pyyaml
+    timm
     tqdm
 
 [options.extras_require]
@@ -59,6 +61,7 @@ console_scripts =
 [options.package_data]
 wsinfer =
     patchlib/presets/*.csv
+    modeldefs/*.yaml
 
 [flake8]
 max-line-length = 88

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 import sys
 
+import click
 from click.testing import CliRunner
 import numpy as np
 import pandas as pd
@@ -50,7 +51,48 @@ def test_cli_list():
     assert result.exit_code == 0
 
 
+def test_cli_run_args(tmp_path: Path):
+    """Test that (model and weights) or config is required."""
+    from wsinfer.cli.cli import cli
+
+    wsi_dir = tmp_path / "slides"
+    wsi_dir.mkdir()
+
+    runner = CliRunner()
+    args = [
+        "run",
+        "--wsi-dir",
+        wsi_dir,
+        "--results-dir",
+        tmp_path / "results",
+    ]
+    # No model, weights, or config.
+    result = runner.invoke(cli, args)
+    assert result.exit_code != 0
+    assert "one of (model and weights) or config is required." in result.output
+
+    # Only one of model and weights.
+    result = runner.invoke(cli, [*args, "--model", "resnet34"])
+    assert result.exit_code != 0
+    assert "model and weights must both be set if one is set." in result.output
+    result = runner.invoke(cli, [*args, "--weights", "TCGA-BRCA-v1"])
+    assert result.exit_code != 0
+    assert "model and weights must both be set if one is set." in result.output
+
+    # config and model
+    result = runner.invoke(cli, [*args, "--config", __file__, "--model", "resnet34"])
+    assert result.exit_code != 0
+    assert "model and weights are mutually exclusive with config." in result.output
+    # config and weights
+    result = runner.invoke(
+        cli, [*args, "--config", __file__, "--weights", "TCGA-BRCA-v1"]
+    )
+    assert result.exit_code != 0
+    assert "model and weights are mutually exclusive with config." in result.output
+
+
 def test_cli_run_and_convert(tiff_image: Path, tmp_path: Path):
+    """This is a form of a regression test."""
     from wsinfer.cli.cli import cli
 
     runner = CliRunner()
@@ -139,3 +181,46 @@ def test_cli_run_and_convert(tiff_image: Path, tmp_path: Path):
 def test_convert_to_sbu():
     # TODO: create a synthetic output and then convert it. Check that it is valid.
     assert False
+
+
+def test_cli_run_from_config(tiff_image: Path, tmp_path: Path):
+    """This is a form of a regression test."""
+    import wsinfer
+    from wsinfer.cli.cli import cli
+
+    # Use config for resnet34 TCGA-BRCA-v1 weights.
+    config = Path(wsinfer.__file__).parent / "modeldefs" / "resnet34_tcga-brca-v1.yaml"
+    assert config.exists()
+
+    runner = CliRunner()
+    results_dir = tmp_path / "inference"
+    result = runner.invoke(
+        cli,
+        [
+            "run",
+            "--wsi-dir",
+            tiff_image.parent,
+            "--config",
+            config,
+            "--results-dir",
+            results_dir,
+        ],
+    )
+    assert result.exit_code == 0
+    assert (results_dir / "model-outputs").exists()
+    df = pd.read_csv(results_dir / "model-outputs" / "purple.csv")
+    assert df.columns.tolist() == [
+        "slide",
+        "minx",
+        "miny",
+        "width",
+        "height",
+        "prob_notumor",
+        "prob_tumor",
+    ]
+    assert (df.loc[:, "slide"] == str(tiff_image)).all()
+    assert (df.loc[:, "width"] == 350).all()
+    assert (df.loc[:, "height"] == 350).all()
+    assert (df.loc[:, "width"] == 350).all()
+    assert np.allclose(df.loc[:, "prob_notumor"], 0.9525967836380005)
+    assert np.allclose(df.loc[:, "prob_tumor"], 0.04740329459309578)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -2,7 +2,6 @@ import json
 from pathlib import Path
 import sys
 
-import click
 from click.testing import CliRunner
 import numpy as np
 import pandas as pd
@@ -224,3 +223,339 @@ def test_cli_run_from_config(tiff_image: Path, tmp_path: Path):
     assert (df.loc[:, "width"] == 350).all()
     assert np.allclose(df.loc[:, "prob_notumor"], 0.9525967836380005)
     assert np.allclose(df.loc[:, "prob_tumor"], 0.04740329459309578)
+
+
+@pytest.mark.parametrize(
+    "modeldef",
+    [
+        [],
+        {},
+        dict(name="foo", architecture="resnet34"),
+        # Missing url
+        dict(
+            name="foo",
+            architecture="resnet34",
+            # url="foo",
+            # url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # missing url_file_name when url is given
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            # url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # url and file used together
+        dict(
+            name="foo",
+            architecture="resnet34",
+            file=__file__,
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # nonexistent file
+        dict(
+            name="foo",
+            architecture="resnet34",
+            file="path/to/fake/file",
+            # url="foo",
+            # url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # num_classes missing
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            # num_classes=1,
+            transform=dict(resize_size=299, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # num classes not equal to len of class names
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=2,
+            transform=dict(resize_size=299, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # transform missing
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            # transform=dict(resize_size=299, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # transform.resize_size missing
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # transform.mean missing
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # transform.std missing
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, mean=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # transform.resize_size non int
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=0.5, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # transform.resize_size non int
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(
+                resize_size=[100, 100], mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]
+            ),
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # transform.mean not a list of three floats
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, mean=[0.5], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # transform.mean not a list of three floats
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, mean=[1, 1, 1], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # transform.mean not a list of three floats
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, mean=0.5, std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # transform.std not a list of three floats
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, std=[0.5], mean=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # transform.std not a list of three floats
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, std=[1, 1, 1], mean=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # transform.std not a list of three floats
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, std=0.5, mean=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # invalid patch_size_pixels -- list
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=[350],
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # invalid patch_size_pixels -- float
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350.0,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # invalid patch_size_pixels -- negative
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=-100,
+            spacing_um_px=0.25,
+            class_names=["tumor"],
+        ),
+        # invalid spacing_um_px -- zero
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=0,
+            class_names=["tumor"],
+        ),
+        # invalid spacing_um_px -- list
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=[0.25],
+            class_names=["tumor"],
+        ),
+        # invalid class_names -- str
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=[0.25],
+            class_names="t",
+        ),
+        # invalid class_names -- len not equal to num_classes
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=[0.25],
+            class_names=["tumor", "nontumor"],
+        ),
+        # invalid class_names -- not list of str
+        dict(
+            name="foo",
+            architecture="resnet34",
+            url="foo",
+            url_file_name="foo",
+            num_classes=1,
+            transform=dict(resize_size=299, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+            patch_size_pixels=350,
+            spacing_um_px=[0.25],
+            class_names=[1],
+        ),
+    ],
+)
+def test_invalid_modeldefs(modeldef, tmp_path: Path):
+    import yaml
+    from wsinfer.modellib.models import Weights
+
+    path = tmp_path / "foobar.yaml"
+    with open(path, "w") as f:
+        yaml.safe_dump(modeldef, f)
+
+    with pytest.raises(Exception):
+        Weights.from_yaml(path)

--- a/wsinfer/cli/infer.py
+++ b/wsinfer/cli/infer.py
@@ -1,10 +1,9 @@
 """Detect cancerous regions in a whole slide image."""
 
 import getpass
-import hashlib
 import json
 import os
-import pathlib
+from pathlib import Path
 import platform
 import subprocess
 import sys
@@ -17,16 +16,16 @@ from ..modellib import models
 from ..patchlib.create_dense_patch_grid import create_grid_and_save_multi_slides
 from ..patchlib.create_patches_fp import create_patches
 
-PathType = typing.Union[str, pathlib.Path]
+PathType = typing.Union[str, Path]
 
 
 def _inside_container() -> str:
-    if pathlib.Path("/.dockerenv").exists():
+    if Path("/.dockerenv").exists():
         return "yes, docker"
     elif (
-        pathlib.Path("/singularity").exists()
-        or pathlib.Path("/singularity.d").exists()
-        or pathlib.Path("/.singularity.d").exists()
+        Path("/singularity").exists()
+        or Path("/singularity.d").exists()
+        or Path("/.singularity.d").exists()
     ):
         # TODO: apptainer might change the name of this directory.
         return "yes, apptainer/singularity"
@@ -82,7 +81,7 @@ def _print_system_info() -> None:
         click.secho("\n*******************************************", fg="yellow")
         click.secho("GPU WILL NOT BE USED", fg="yellow")
         if torch.version.cuda is None:
-            click.secho("  CPU-only version of PyTorch", fg="yellow")
+            click.secho("  CPU-only version of PyTorch is installed", fg="yellow")
         click.secho("*******************************************", fg="yellow")
     elif not torch.cuda.is_available():
         click.secho("\n*******************************************", fg="yellow")
@@ -92,32 +91,20 @@ def _print_system_info() -> None:
         click.secho("*******************************************", fg="yellow")
 
 
-def _sha256sum(path: PathType) -> str:
-    """Calculate SHA256 of a file."""
-    sha = hashlib.sha256()
-    with open(path, "rb") as f:
-        while True:
-            data = f.read(1024 * 64)  # 64 kb
-            if not data:
-                break
-            sha.update(data)
-    return sha.hexdigest()
-
-
 def _get_info_for_save(weights: models.Weights):
     """Get dictionary with information about the run. To save as JSON in output dir."""
 
     import torch
     from .. import __version__
 
-    here = pathlib.Path(__file__).parent.resolve()
+    here = Path(__file__).parent.resolve()
 
     def get_git_info():
-        here = pathlib.Path(__file__).parent.resolve()
+        here = Path(__file__).parent.resolve()
 
         def get_stdout(args) -> str:
             proc = subprocess.run(args, capture_output=True, cwd=here)
-            return proc.stdout.decode().strip()
+            return "" if proc.returncode != 0 else proc.stdout.decode().strip()
 
         git_remote = get_stdout("git config --get remote.origin.url".split())
         git_branch = get_stdout("git rev-parse --abbrev-ref HEAD".split())
@@ -132,9 +119,6 @@ def _get_info_for_save(weights: models.Weights):
             "git_commit": git_commit,
             "uncommitted_changes": uncommitted_changes,
         }
-
-    weights_path = pathlib.Path(torch.hub.get_dir()) / "checkpoints" / weights.file_name
-    shasum = _sha256sum(weights_path) if weights_path.exists() else None
 
     # Test if we are in a git repo. If we are, then get git info.
     cmd = subprocess.run(
@@ -151,17 +135,16 @@ def _get_info_for_save(weights: models.Weights):
 
     return {
         "model": {
-            "architecture": "resnet34",
+            "architecture": weights.architecture,
             "weights_url": weights.url,
-            "weights_path": str(weights_path) if weights_path.exists() else None,
-            "weights_sha256": shasum,
+            "weights_url_file_name": weights.url_file_name,
+            "weights_file": weights.file,
+            "weights_sha256": weights.get_sha256_of_weights(),
             "class_names": weights.class_names,
             "num_classes": weights.num_classes,
-            "metadata": weights.metadata or None,
-        },
-        "input_data": {
             "patch_size_pixels": weights.patch_size_pixels,
             "spacing_um_px": weights.spacing_um_px,
+            "metadata": weights.metadata or None,
         },
         "runtime": {
             "version": __version__,
@@ -182,31 +165,36 @@ def _get_info_for_save(weights: models.Weights):
 @click.pass_context
 @click.option(
     "--wsi-dir",
-    type=click.Path(
-        exists=True, file_okay=False, path_type=pathlib.Path, resolve_path=True
-    ),
+    type=click.Path(exists=True, file_okay=False, path_type=Path, resolve_path=True),
     required=True,
     help="Directory containing whole slide images. This directory can *only* contain"
     " whole slide images.",
 )
 @click.option(
     "--results-dir",
-    type=click.Path(file_okay=False, path_type=pathlib.Path, resolve_path=True),
+    type=click.Path(file_okay=False, path_type=Path, resolve_path=True),
     required=True,
     help="Directory to store results. If directory exists, will skip"
     " whole slides for which outputs exist.",
 )
 @click.option(
     "--model",
-    type=click.Choice(models.list_models()),
-    required=True,
-    help="Model architecture to use.",
+    type=click.Choice([arch for arch, _ in models.list_all_models_and_weights()]),
+    help="Model architecture to use. Not required if 'config' is used.",
 )
 @click.option(
     "--weights",
-    type=str,
-    required=True,
-    help="Weights to use for the model.",
+    type=click.Choice([w for _, w in models.list_all_models_and_weights()]),
+    help="Name of weights to use for the model. Not required if 'config' is used.",
+)
+@click.option(
+    "--config",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path, resolve_path=True),
+    help=(
+        "Path to configuration for architecture and weights. Use this option if the"
+        " model weights are not registered in wsinfer. Mutually exclusive with"
+        " 'model' and 'weights'."
+    ),
 )
 @click.option(
     "--batch-size",
@@ -219,6 +207,7 @@ def _get_info_for_save(weights: models.Weights):
     "--num-workers",
     default=0,
     show_default=True,
+    type=click.IntRange(min=0),
     help="Number of workers to use for data loading during model inference (default=0"
     " for single thread). A reasonable value is 8.",
 )
@@ -232,10 +221,11 @@ def _get_info_for_save(weights: models.Weights):
 def cli(
     ctx: click.Context,
     *,
-    wsi_dir: pathlib.Path,
-    results_dir: pathlib.Path,
-    model: str,
-    weights: str,
+    wsi_dir: Path,
+    results_dir: Path,
+    model: typing.Optional[str],
+    weights: typing.Optional[str],
+    config: typing.Optional[Path],
     batch_size: int,
     num_workers: int = 0,
     dense_grid: bool = False,
@@ -251,6 +241,12 @@ def cli(
     CUDA_VISIBLE_DEVICES=0 wsinfer run --wsi_dir slides/ --results_dir results
     --model resnet34 --weights TCGA-BRCA-v1 --batch_size 32 --num_workers 4
     """
+    if model is None and weights is None and config is None:
+        raise click.UsageError("one of (model and weights) or config is required.")
+    elif (model is not None or weights is not None) and config is not None:
+        raise click.UsageError("model and weights are mutually exclusive with config.")
+    elif (model is not None) ^ (weights is not None):  # XOR
+        raise click.UsageError("model and weights must both be set if one is set.")
 
     wsi_dir = wsi_dir.resolve()
     results_dir = results_dir.resolve()
@@ -275,9 +271,12 @@ def cli(
         print(f"{key} = {value}")
     print("----------------------\n")
 
-    # Get model before running the patching script because we need to get the necessary
-    # spacing and patch size.
-    weights_obj = models.create_model(model, weights=weights)
+    # Get weights object before running the patching script because we need to get the
+    # necessary spacing and patch size.
+    if model is not None and weights is not None:
+        weights_obj = models.get_model_weights(model, name=weights)
+    elif config is not None:
+        weights_obj = models.Weights.from_yaml(config)
 
     click.secho("\nFinding patch coordinates...\n", fg="green")
     if dense_grid:

--- a/wsinfer/modeldefs/inceptionv4_tcga-brca-v1.yaml
+++ b/wsinfer/modeldefs/inceptionv4_tcga-brca-v1.yaml
@@ -1,0 +1,22 @@
+# Configuration of a breast cancer tumor detection model.
+# The models are referenced by the pair of [architecture, weights], so this pair must
+# be unique.
+architecture: inceptionv4  # Must be a string.
+name: TCGA-BRCA-v1  # Must be a string.
+# Where to get the model weights. Either a URL or path to a file.
+# If using a URL, set the url_file_name (the name of the file when it is downloaded).
+url: https://stonybrookmedicine.box.com/shared/static/tfwimlf3ygyga1x4fnn03u9y5uio8gqk.pt
+url_file_name: inceptionv4-brca-20190613-aef40942.pt
+# If using a relative path, the path is relative to the location of the yaml file.
+# file: /path/to/weights.pt
+num_classes: 2
+transform:
+  # These are keyword arguments to the PatchClassification class.
+  resize_size: 299  # Must be a single integer.
+  mean: [0.5, 0.5, 0.5]  # Must be a list of three floats.
+  std: [0.5, 0.5, 0.5]  # Must be a list of three floats.
+patch_size_pixels: 350
+spacing_um_px: 0.25
+class_names:
+  - notumor
+  - tumor

--- a/wsinfer/modeldefs/inceptionv4nobn_tcga-tils-v1.yaml
+++ b/wsinfer/modeldefs/inceptionv4nobn_tcga-tils-v1.yaml
@@ -1,0 +1,28 @@
+# Configuration of a tumor infiltrating lymphocyte detection model.
+# The models are referenced by the pair of [architecture, weights], so this pair must
+# be unique.
+# Inceptionv4 without batch normalization.
+architecture: inceptionv4nobn  # Must be a string.
+name: TCGA-TILs-v1  # Must be a string.
+# Where to get the model weights. Either a URL or path to a file.
+# If using a URL, set the url_file_name (the name of the file when it is downloaded).
+url: https://stonybrookmedicine.box.com/shared/static/sz1gpc6u3mftadh4g6x3csxnpmztj8po.pt
+url_file_name: inceptionv4-tils-v1-20200920-e3e72cd2.pt
+# If using a relative path, the path is relative to the location of the yaml file.
+# file: /path/to/weights.pt
+num_classes: 2
+transform:
+  # These are keyword arguments to the PatchClassification class.
+  resize_size: 299  # Must be a single integer.
+  mean: [0.5, 0.5, 0.5]  # Must be a list of three floats.
+  std: [0.5, 0.5, 0.5]  # Must be a list of three floats.
+patch_size_pixels: 100
+spacing_um_px: 0.5
+class_names:
+  - notils
+  - tils
+metadata:
+  publication: https://doi.org/10.3389/fonc.2021.806603
+  notes: |
+    Implementation does not use batchnorm. Original model was trained with TF Slim
+    and converted to PyTorch format.

--- a/wsinfer/modeldefs/preactresnet34_tcga-paad-v1.yaml
+++ b/wsinfer/modeldefs/preactresnet34_tcga-paad-v1.yaml
@@ -1,0 +1,24 @@
+# Configuration of a pancreatic adenocarcinoma tumor detection model.
+# The models are referenced by the pair of [architecture, weights], so this pair must
+# be unique.
+architecture: preactresnet34  # Must be a string.
+name: TCGA-PAAD-v1  # Must be a string.
+# Where to get the model weights. Either a URL or path to a file.
+# If using a URL, set the url_file_name (the name of the file when it is downloaded).
+url: https://stonybrookmedicine.box.com/shared/static/sol1h9aqrh8lynzc6kidw1lsoeks20hh.pt
+url_file_name: preactresnet34-paad-20210101-7892b41f.pt
+# If using a relative path, the path is relative to the location of the yaml file.
+# file: /path/to/weights.pt
+num_classes: 1
+transform:
+  # These are keyword arguments to the PatchClassification class.
+  resize_size: 224  # Must be a single integer.
+  mean: [0.7238, 0.5716, 0.6779]
+  std: [0.1120, 0.1459, 0.1089]
+patch_size_pixels: 350
+# Patches are 525.1106 microns.
+# Patch of 2078 pixels @ 0.2527 mpp is 350 pixels at our target spacing.
+# (2078 * 0.2527) / 350
+spacing_um_px: 1.500316
+class_names:
+  - tumor

--- a/wsinfer/modeldefs/resnet34_tcga-brca-v1.yaml
+++ b/wsinfer/modeldefs/resnet34_tcga-brca-v1.yaml
@@ -1,0 +1,22 @@
+# Configuration of a breast cancer tumor detection model.
+# The models are referenced by the pair of [architecture, weights], so this pair must
+# be unique.
+architecture: resnet34  # Must be a string.
+name: TCGA-BRCA-v1  # Must be a string.
+# Where to get the model weights. Either a URL or path to a file.
+# If using a URL, set the url_file_name (the name of the file when it is downloaded).
+url: https://stonybrookmedicine.box.com/shared/static/dv5bxk6d15uhmcegs9lz6q70yrmwx96p.pt
+url_file_name: resnet34-brca-20190613-01eaf604.pt
+# If using a relative path, the path is relative to the location of the yaml file.
+# file: /path/to/weights.pt
+num_classes: 2
+transform:
+  # These are keyword arguments to the PatchClassification class.
+  resize_size: 224  # Must be a single integer.
+  mean: [0.7238, 0.5716, 0.6779]  # Must be a list of three floats.
+  std: [0.1120, 0.1459, 0.1089]  # Must be a list of three floats.
+patch_size_pixels: 350
+spacing_um_px: 0.25
+class_names:
+  - notumor
+  - tumor

--- a/wsinfer/modeldefs/resnet34_tcga-luad-v1.yaml
+++ b/wsinfer/modeldefs/resnet34_tcga-luad-v1.yaml
@@ -1,0 +1,26 @@
+# Configuration of a lung adenocarcinoma tumor detection model.
+# The models are referenced by the pair of [architecture, weights], so this pair must
+# be unique.
+architecture: resnet34  # Must be a string.
+name: TCGA-LUAD-v1  # Must be a string.
+# Where to get the model weights. Either a URL or path to a file.
+# If using a URL, set the url_file_name (the name of the file when it is downloaded).
+url: https://stonybrookmedicine.box.com/shared/static/d6g9huv1olfu2mt9yaud9xqf9bdqx38i.pt
+url_file_name: resnet34-luad-20210102-93038ae6.pt
+# If using a relative path, the path is relative to the location of the yaml file.
+# file: /path/to/weights.pt
+num_classes: 6
+transform:
+  # These are keyword arguments to the PatchClassification class.
+  resize_size: 224  # Must be a single integer.
+  mean: [0.8301, 0.6600, 0.8054]
+  std: [0.0864, 0.1602, 0.0647]
+patch_size_pixels: 350
+spacing_um_px: 0.5
+class_names:
+  - lepidic
+  - benign
+  - acinar
+  - micropapillary
+  - mucinous
+  - solid

--- a/wsinfer/modeldefs/resnet34_tcga-prad-v1.yaml
+++ b/wsinfer/modeldefs/resnet34_tcga-prad-v1.yaml
@@ -1,0 +1,23 @@
+# Configuration of a prostate adenocarcinoma tumor detection model.
+# The models are referenced by the pair of [architecture, weights], so this pair must
+# be unique.
+architecture: resnet34  # Must be a string.
+name: TCGA-PRAD-v1  # Must be a string.
+# Where to get the model weights. Either a URL or path to a file.
+# If using a URL, set the url_file_name (the name of the file when it is downloaded).
+url: https://stonybrookmedicine.box.com/shared/static/nxyr5atk2nlvgibck3l0q6rjin2g7n38.pt
+url_file_name: resnet34-prad-20210101-ea6c004c.pt
+# If using a relative path, the path is relative to the location of the yaml file.
+# file: /path/to/weights.pt
+num_classes: 3
+transform:
+  # These are keyword arguments to the PatchClassification class.
+  resize_size: 224  # Must be a single integer.
+  mean: [0.6462, 0.5070, 0.8055]
+  std: [0.1381, 0.1674, 0.1358]
+patch_size_pixels: 175
+spacing_um_px: 0.5
+class_names:
+  - grade3
+  - grade4+5
+  - benign

--- a/wsinfer/modeldefs/vgg16mod_tcga-BRCA-v1.yaml
+++ b/wsinfer/modeldefs/vgg16mod_tcga-BRCA-v1.yaml
@@ -1,0 +1,27 @@
+# Configuration of a tumor infiltrating lymphocyte detection model.
+# The models are referenced by the pair of [architecture, weights], so this pair must
+# be unique.
+# Inceptionv4 without batch normalization.
+architecture: vgg16mod  # Must be a string.
+name: TCGA-BRCA-v1  # Must be a string.
+# Where to get the model weights. Either a URL or path to a file.
+# If using a URL, set the url_file_name (the name of the file when it is downloaded).
+url: https://stonybrookmedicine.box.com/shared/static/197s56yvcrdpan7eu5tq8d4gxvq3xded.pt
+url_file_name: vgg16-modified-brca-20190613-62bc1b41.pt
+# If using a relative path, the path is relative to the location of the yaml file.
+# file: /path/to/weights.pt
+num_classes: 2
+transform:
+  # These are keyword arguments to the PatchClassification class.
+  resize_size: 224  # Must be a single integer.
+  mean: [0.7238, 0.5716, 0.6779]  # Must be a list of three floats.
+  std: [0.1120, 0.1459, 0.1089]  # Must be a list of three floats.
+patch_size_pixels: 350
+spacing_um_px: 0.25
+class_names:
+  - notumor
+  - tumor
+metadata:
+  notes: |
+    This model is a modified VGG16. The second-to-last linear layer was removed. See
+    https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7369575/table/tbl3/ for details.

--- a/wsinfer/modellib/inceptionv4.py
+++ b/wsinfer/modellib/inceptionv4.py
@@ -327,51 +327,5 @@ class InceptionV4(nn.Module):
         return x
 
 
-def inceptionv4(num_classes=1000, pretrained="imagenet"):
-    if pretrained:
-        settings = pretrained_settings["inceptionv4"][pretrained]
-        assert (
-            num_classes == settings["num_classes"]
-        ), "num_classes should be {}, but is {}".format(
-            settings["num_classes"], num_classes
-        )
-
-        # both 'imagenet'&'imagenet+background' are loaded from same parameters
-        model = InceptionV4(num_classes=1001)
-        model.load_state_dict(model_zoo.load_url(settings["url"]))
-
-        if pretrained == "imagenet":
-            new_last_linear = nn.Linear(1536, 1000)
-            new_last_linear.weight.data = model.last_linear.weight.data[1:]
-            new_last_linear.bias.data = model.last_linear.bias.data[1:]
-            model.last_linear = new_last_linear
-
-        model.input_space = settings["input_space"]
-        model.input_size = settings["input_size"]
-        model.input_range = settings["input_range"]
-        model.mean = settings["mean"]
-        model.std = settings["std"]
-    else:
-        model = InceptionV4(num_classes=num_classes)
-    return model
-
-
-"""
-TEST
-Run this code with:
-```
-cd $HOME/pretrained-models.pytorch
-python -m pretrainedmodels.inceptionv4
-```
-"""
-if __name__ == "__main__":
-
-    assert inceptionv4(num_classes=10, pretrained=None)
-    print("success")
-    assert inceptionv4(num_classes=1000, pretrained="imagenet")
-    print("success")
-    assert inceptionv4(num_classes=1001, pretrained="imagenet+background")
-    print("success")
-
-    # fail
-    assert inceptionv4(num_classes=1001, pretrained="imagenet")
+def inceptionv4(num_classes: int):
+    return InceptionV4(num_classes=num_classes)

--- a/wsinfer/modellib/inceptionv4_no_batchnorm.py
+++ b/wsinfer/modellib/inceptionv4_no_batchnorm.py
@@ -298,8 +298,5 @@ class InceptionV4(nn.Module):
         return x
 
 
-def inceptionv4(num_classes=1000, pretrained=False):
-    if pretrained:
-        raise NotImplementedError()
-    model = InceptionV4(num_classes=num_classes)
-    return model
+def inceptionv4(num_classes=1000):
+    return InceptionV4(num_classes=num_classes)

--- a/wsinfer/modellib/models.py
+++ b/wsinfer/modellib/models.py
@@ -1,11 +1,7 @@
-"""Models for whole slide image patch-based classification.
-
-See https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7369575/table/tbl3/ for modifications
-that were made to the original architectures.
-"""
-
 import dataclasses
-import pathlib
+import hashlib
+import os
+from pathlib import Path
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -15,39 +11,63 @@ from typing import Tuple
 from typing import Union
 
 from PIL import Image
+import timm
 import torch
 from torch.hub import load_state_dict_from_url
-import torchvision
+import yaml
 
 from .inceptionv4 import inceptionv4 as _inceptionv4
 from .inceptionv4_no_batchnorm import inceptionv4 as _inceptionv4_no_bn
 from .resnet_preact import resnet34_preact as _resnet34_preact
 from .transforms import PatchClassification
 
-PathType = Union[str, pathlib.Path]
+
+class WsinferException(Exception):
+    "Base class for wsinfer exceptions."
 
 
-class ModelNotFoundError(Exception):
-    ...
+class UnknownArchitectureError(WsinferException):
+    """Architecture is unknown and cannot be found."""
 
 
-class WeightsNotFoundError(Exception):
-    ...
+class ModelWeightsNotFound(WsinferException):
+    """Model weights are not found, likely because they are not in the registry."""
+
+
+class DuplicateModelWeights(WsinferException):
+    """A duplicate key was passed to the model weights registry."""
+
+
+PathType = Union[str, Path]
+
+
+def _sha256sum(path: PathType) -> str:
+    """Calculate SHA256 of a file."""
+    sha = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            data = f.read(1024 * 64)  # 64 kb
+            if not data:
+                break
+            sha.update(data)
+    return sha.hexdigest()
 
 
 @dataclasses.dataclass
 class Weights:
     """Container for data associated with a trained model."""
 
-    url: str
-    file_name: str
+    name: str
+    architecture: str
     num_classes: int
     transform: Callable[[Union[Image.Image, torch.Tensor]], torch.Tensor]
     patch_size_pixels: int
     spacing_um_px: float
     class_names: List[str]
-    metadata: Dict[str, Any]
-    model: Optional[torch.nn.Module] = None
+    url: Optional[str] = None
+    url_file_name: Optional[str] = None
+    file: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
 
     def __post_init__(self):
         if len(set(self.class_names)) != len(self.class_names):
@@ -55,274 +75,196 @@ class Weights:
         if len(self.class_names) != self.num_classes:
             raise ValueError("length of class_names must be equal to num_classes")
 
+    @classmethod
+    def from_yaml(cls, path):
+        with open(path) as f:
+            d = yaml.safe_load(f)
 
-# Store all available weights for all models.
-WEIGHTS: Dict[str, Dict[str, Weights]] = {
-    "inceptionv4": {
-        "TCGA-BRCA-v1": Weights(
-            url="https://stonybrookmedicine.box.com/shared/static/tfwimlf3ygyga1x4fnn03u9y5uio8gqk.pt",  # noqa
-            file_name="inceptionv4-brca-20190613-aef40942.pt",
-            num_classes=2,
-            transform=PatchClassification(
-                resize_size=299,
-                mean=(0.5, 0.5, 0.5),
-                std=(0.5, 0.5, 0.5),
-            ),
-            patch_size_pixels=350,
-            spacing_um_px=0.25,
-            class_names=["notumor", "tumor"],
-            metadata={"patch-size": "350 pixels (87.5 microns)"},
-        ),
-        # This uses an implementation without batchnorm. Model was trained with TF Slim
-        # and weights were converted to PyTorch (see 'scripts' directory).
-        "TCGA-TILs-v1": Weights(
-            url="https://stonybrookmedicine.box.com/shared/static/sz1gpc6u3mftadh4g6x3csxnpmztj8po.pt",  # noqa
-            file_name="inceptionv4-tils-v1-20200920-e3e72cd2.pt",
-            num_classes=2,
-            transform=PatchClassification(
-                resize_size=299, mean=(0.5, 0.5, 0.5), std=(0.5, 0.5, 0.5)
-            ),
-            patch_size_pixels=100,
-            spacing_um_px=0.5,
-            class_names=["notils", "tils"],
-            metadata={
-                "publication": "https://doi.org/10.3389/fonc.2021.806603",
-                "notes": (
-                    "Implementation does not use batchnorm. Original model was trained"
-                    " with TF Slim and converted to PyTorch format."
-                ),
-            },
-        ),
-    },
-    "resnet34": {
-        "TCGA-BRCA-v1": Weights(
-            url="https://stonybrookmedicine.box.com/shared/static/dv5bxk6d15uhmcegs9lz6q70yrmwx96p.pt",  # noqa
-            file_name="resnet34-brca-20190613-01eaf604.pt",
-            num_classes=2,
-            transform=PatchClassification(
-                resize_size=224,
-                mean=(0.7238, 0.5716, 0.6779),
-                std=(0.1120, 0.1459, 0.1089),
-            ),
-            patch_size_pixels=350,
-            spacing_um_px=0.25,
-            class_names=["notumor", "tumor"],
-            metadata={"patch-size": "350 pixels (87.5 microns)."},
-        ),
-        # Original model is on GitHub
-        # https://github.com/SBU-BMI/quip_lung_cancer_detection/blob/8eac86e837baa371a98ce2fe08348dcf0400a317/models_cnn/train_lung_john_6classes_netDepth-34_APS-350_randomSeed-2954321_numBenign-80000_0131_1818_bestF1_0.8273143068611924_5.t7
-        "TCGA-LUAD-v1": Weights(
-            url="https://stonybrookmedicine.box.com/shared/static/d6g9huv1olfu2mt9yaud9xqf9bdqx38i.pt",  # noqa
-            file_name="resnet34-luad-20210102-93038ae6.pt",
-            num_classes=6,
-            transform=PatchClassification(
-                resize_size=224,
-                # Mean and std from
-                # https://github.com/SBU-BMI/quip_lung_cancer_detection/blob/8eac86e837baa371a98ce2fe08348dcf0400a317/prediction_6classes/tumor_pred/pred.py#L29-L30
-                mean=(0.8301, 0.6600, 0.8054),
-                std=(0.0864, 0.1602, 0.0647),
-            ),
-            patch_size_pixels=350,
-            spacing_um_px=0.5,
-            class_names=[
-                "lepidic",
-                "benign",
-                "acinar",
-                "micropapillary",
-                "mucinous",
-                "solid",
-            ],
-            metadata={},
-        ),
-        # Original model is on GitHub
-        # https://github.com/SBU-BMI/quip_prad_cancer_detection/tree/d80052e0d098a1211432f9abff086974edd9c669/models_cnn
-        # Original file name is
-        # RESNET_34_prostate_beatrice_john___1117_1038_0.9533516227597434_87.t7
-        "TCGA-PRAD-v1": Weights(
-            url="https://stonybrookmedicine.box.com/shared/static/nxyr5atk2nlvgibck3l0q6rjin2g7n38.pt",  # noqa
-            file_name="resnet34-prad-20210101-ea6c004c.pt",
-            num_classes=3,
-            transform=PatchClassification(
-                resize_size=224,
-                # Mean and std from
-                # https://github.com/SBU-BMI/quip_prad_cancer_detection/blob/b71d8440eab090cb789281b33fbf89011e924fb9/prediction_3classes/tumor_pred/pred.py#L27-L28
-                mean=(0.6462, 0.5070, 0.8055),
-                std=(0.1381, 0.1674, 0.1358),
-            ),
-            patch_size_pixels=175,
-            spacing_um_px=0.5,
-            class_names=["grade3", "grade4+5", "benign"],
-            metadata={},
-        ),
-    },
-    "resnet34_preact": {
-        "TCGA-PAAD-v1": Weights(
-            url="https://stonybrookmedicine.box.com/shared/static/sol1h9aqrh8lynzc6kidw1lsoeks20hh.pt",  # noqa
-            file_name="preactresnet34-paad-20210101-7892b41f.pt",
-            num_classes=1,
-            transform=PatchClassification(
-                resize_size=224,
-                mean=(0.7238, 0.5716, 0.6779),
-                std=(0.1120, 0.1459, 0.1089),
-            ),
-            patch_size_pixels=350,
-            # Patches are 525.1106 microns.
-            # Patch of 2078 pixels @ 0.2527 mpp is 350 pixels at our target spacing.
-            # (2078 * 0.2527) / 350
-            spacing_um_px=1.500316,
-            class_names=["tumor"],
-            metadata={},
-        ),
-    },
-    "vgg16_modified": {
-        "TCGA-BRCA-v1": Weights(
-            url="https://stonybrookmedicine.box.com/shared/static/197s56yvcrdpan7eu5tq8d4gxvq3xded.pt",  # noqa
-            file_name="vgg16-modified-brca-20190613-62bc1b41.pt",
-            num_classes=2,
-            transform=PatchClassification(
-                resize_size=224,
-                mean=(0.7238, 0.5716, 0.6779),
-                std=(0.1120, 0.1459, 0.1089),
-            ),
-            patch_size_pixels=350,
-            spacing_um_px=0.25,
-            class_names=["notumor", "tumor"],
-            metadata={"patch-size": "350 pixels (87.5 microns)"},
+        if not isinstance(d, dict):
+            raise ValueError("expected YAML config to be a dictionary")
+
+        # Validate contents.
+        # Validate keys.
+        required_keys = [
+            "name",
+            "architecture",
+            "num_classes",
+            "transform",
+            "patch_size_pixels",
+            "spacing_um_px",
+            "class_names",
+        ]
+        optional_keys = ["url", "url_file_name", "file", "metadata"]
+        all_keys = required_keys + optional_keys
+        for req_key in required_keys:
+            if req_key not in d.keys():
+                raise KeyError(f"required key not found: '{req_key}'")
+        unknown_keys = [k for k in d.keys() if k not in all_keys]
+        if unknown_keys:
+            raise KeyError(f"unknown keys: {unknown_keys}")
+        for req_key in ["resize_size", "mean", "std"]:
+            if req_key not in d["transform"].keys():
+                raise KeyError(
+                    f"required key not found in 'transform' section: '{req_key}'"
+                )
+
+        # Either 'url' or 'file' is required. If 'url' is used, then 'url_file_name' is
+        # required.
+        if "url" not in d.keys() and "file" not in d.keys():
+            raise KeyError("'url' or 'file' must be provided")
+        if "url" in d.keys() and "file" in d.keys():
+            raise KeyError("only on of 'url' and 'file' can be used")
+        if "url" in d.keys() and "url_file_name" not in d.keys():
+            raise KeyError("when using 'url', 'url_file_name' must also be provided")
+
+        # Validate types.
+        if not isinstance("architecture", str):
+            raise ValueError("'architecture' must be a string")
+        if not isinstance("name", str):
+            raise ValueError("'name' must be a string")
+        if "url" in d.keys() and not isinstance(d["url"], str):
+            raise ValueError("'url' must be a string")
+        if "url_file_name" in d.keys() and not isinstance(d["url"], str):
+            raise ValueError("'url_file_name' must be a string")
+        if not isinstance(d["num_classes"], int):
+            raise ValueError("'num_classes' must be an integer")
+        if not isinstance(d["transform"]["resize_size"], int):
+            raise ValueError("'transform.resize_size' must be an integer")
+        if not isinstance(d["transform"]["mean"], list):
+            raise ValueError("'transform.mean' must be a list")
+        if not all(isinstance(num, float) for num in d["transform"]["mean"]):
+            raise ValueError("'transform.mean' must be a list of floats")
+        if not isinstance(d["transform"]["std"], list):
+            raise ValueError("'transform.std' must be a list")
+        if not all(isinstance(num, float) for num in d["transform"]["std"]):
+            raise ValueError("'transform.std' must be a list of floats")
+        if not isinstance(d["patch_size_pixels"], int) or d["patch_size_pixels"] <= 0:
+            raise ValueError("patch_size_pixels must be a positive integer")
+        if not isinstance(d["spacing_um_px"], float) or d["spacing_um_px"] <= 0:
+            raise ValueError("spacing_um_px must be a positive float")
+        if not isinstance(d["class_names"], list):
+            raise ValueError("'class_names' must be a list")
+        if not all(isinstance(c, str) for c in d["class_names"]):
+            raise ValueError("'class_names' must be a list of strings")
+
+        # Validate values.
+        if len(d["transform"]["mean"]) != 3:
+            raise ValueError("transform.mean must be a list of three numbers")
+        if len(d["transform"]["std"]) != 3:
+            raise ValueError("transform.std must be a list of three numbers")
+        if len(d["class_names"]) != len(set(d["class_names"])):
+            raise ValueError("duplicate values found in 'class_names'")
+        if len(d["class_names"]) != d["num_classes"]:
+            raise ValueError("mismatch between length of class_names and num_classes.")
+        if "file" in d.keys():
+            file = Path(path).parent / d["file"]
+            file = file.resolve()
+            if not file.exists():
+                raise FileNotFoundError(f"'file' not found: {file}")
+
+        transform = PatchClassification(
+            resize_size=d["transform"]["resize_size"],
+            mean=d["transform"]["mean"],
+            std=d["transform"]["std"],
         )
-    },
+        return Weights(
+            name=d["name"],
+            architecture=d["architecture"],
+            url=d.get("url"),
+            url_file_name=d.get("url_file_name"),
+            file=d.get("file"),
+            num_classes=d["num_classes"],
+            transform=transform,
+            patch_size_pixels=d["patch_size_pixels"],
+            spacing_um_px=d["spacing_um_px"],
+            class_names=d["class_names"],
+        )
+
+    def load_model(self):
+        model = _create_model(name=self.architecture, num_classes=self.num_classes)
+
+        # Load state dict.
+        if self.url and self.url_file_name:
+            state_dict = load_state_dict_from_url(
+                url=self.url, check_hash=True, file_name=self.url_file_name
+            )
+        elif self.file:
+            state_dict = torch.load(self.file, map_location="cpu")
+        else:
+            raise RuntimeError("cannot find weights")
+
+        model.load_state_dict(state_dict, strict=True)
+        return model
+
+    def get_sha256_of_weights(self) -> str:
+        if self.url and self.url_file_name:
+            p = Path(torch.hub.get_dir()) / "checkpoints" / self.url_file_name
+        elif self.file:
+            p = Path(self.file)
+        else:
+            raise RuntimeError("cannot find path to weights")
+        sha = _sha256sum(p)
+        return sha
+
+
+# Container for all models we can use that are not in timm.
+_model_registry: Dict[str, Callable[[int], torch.nn.Module]] = {
+    "inceptionv4": _inceptionv4,
+    "inceptionv4nobn": _inceptionv4_no_bn,
+    "preactresnet34": _resnet34_preact,
 }
 
 
-def _get_model_weights(model_name: str, weights: str) -> Weights:
-    all_weights_for_model = WEIGHTS.get(model_name)
-    if all_weights_for_model is None:
-        raise ModelNotFoundError(f"no weights registered for {model_name}")
-    weights_obj = all_weights_for_model.get(weights)
-    if weights_obj is None:
-        raise WeightsNotFoundError(f"'{weights}' weights not found for {model_name}")
-    return weights_obj
-
-
-def _load_state_into_model(model: torch.nn.Module, weights: Weights):
-    print("Information about the pretrained weights")
-    print("----------------------------------------")
-    for k, v in dataclasses.asdict(weights).items():
-        if k == "model":  # skip because it's None at this point.
-            continue
-        print(f"{k} = {v}")
-    print("----------------------------------------\n")
-    state_dict = load_state_dict_from_url(
-        url=weights.url, check_hash=True, file_name=weights.file_name
-    )
-    model.load_state_dict(state_dict, strict=True)
-    return model
-
-
-def inceptionv4(weights: str) -> Weights:
-    """Create InceptionV4 model."""
-    weights_obj = _get_model_weights("inceptionv4", weights=weights)
-    if weights == "TCGA-TILs-v1":
-        # TCGA-TILs-v1 model uses inceptionv4 without batchnorm.
-        model = _inceptionv4_no_bn(weights_obj.num_classes, pretrained=False)
+def _create_model(name: str, num_classes: int) -> torch.nn.Module:
+    """Return a torch model architecture."""
+    if name in _model_registry.keys():
+        return _model_registry[name](num_classes)
     else:
-        model = _inceptionv4(num_classes=weights_obj.num_classes, pretrained=False)
-    model = _load_state_into_model(model=model, weights=weights_obj)
-    weights_obj.model = model
-    return weights_obj
+        if name not in timm.list_models():
+            raise UnknownArchitectureError(f"unknown architecture: '{name}'")
+        return timm.create_model(name, num_classes=num_classes)
 
 
-def resnet34(weights: str) -> Weights:
-    """Create ResNet34 model."""
-    weights_obj = _get_model_weights("resnet34", weights=weights)
-    model = torchvision.models.resnet34()
-    model.fc = torch.nn.Linear(model.fc.in_features, weights_obj.num_classes)
-    model = _load_state_into_model(model=model, weights=weights_obj)
-    weights_obj.model = model
-    return weights_obj
+# Keys are tuple of (architecture, weights_name).
+_known_model_weights: Dict[Tuple[str, str], Weights] = {}
 
 
-def resnet34_preact(weights: str) -> Weights:
-    """Create ResNet34-Preact model."""
-    weights_obj = _get_model_weights("resnet34_preact", weights=weights)
-    model = _resnet34_preact()
-    model.linear = torch.nn.Linear(model.linear.in_features, weights_obj.num_classes)
-    model = _load_state_into_model(model=model, weights=weights_obj)
-    weights_obj.model = model
-    return weights_obj
+def register_model_weights(root: Path):
+    modeldefs = list(root.glob("*.yml")) + list(root.glob("*.yaml"))
+    for modeldef in modeldefs:
+        w = Weights.from_yaml(modeldef)
+        if w.architecture not in timm.list_models() + _model_registry.keys():
+            raise UnknownArchitectureError(f"{w.architecture} implementation not found")
+        key = (w.architecture, w.name)
+        if key in _known_model_weights:
+            raise DuplicateModelWeights("")
+        _known_model_weights[key] = w
 
 
-def vgg16_modified(weights: str) -> Weights:
-    """Create modified VGG16 model.
-
-    The classifier of this model is
-        Linear (25,088, 4096)
-        ReLU -> Dropout
-        Linear (1024, num_classes)
-    """
-    weights_obj = _get_model_weights("vgg16_modified", weights=weights)
-    model = torchvision.models.vgg16()
-    model.classifier = model.classifier[:4]
-    in_features = model.classifier[0].in_features
-    model.classifier[0] = torch.nn.Linear(in_features, 1024)
-    model.classifier[3] = torch.nn.Linear(1024, weights_obj.num_classes)
-    model = _load_state_into_model(model=model, weights=weights_obj)
-    weights_obj.model = model
-    return weights_obj
-
-
-MODEL_NAME_TO_FUNC = dict(
-    inceptionv4=inceptionv4,
-    resnet34=resnet34,
-    resnet34_preact=resnet34_preact,
-    vgg16_modified=vgg16_modified,
-)
-if not set(WEIGHTS.keys()).issubset(MODEL_NAME_TO_FUNC.keys()):
-    raise RuntimeError("Not all model functions are defined.")
-
-
-def list_models() -> List[str]:
-    return list(WEIGHTS.keys())
-
-
-def list_available_weights_for_model(model_name: str) -> List[str]:
+def get_model_weights(architecture: str, name: str) -> Weights:
+    """Get weights object for an architecture and weights name."""
+    key = (architecture, name)
     try:
-        return list(WEIGHTS[model_name].keys())
+        return _known_model_weights[key]
     except KeyError:
-        return []
+        raise ModelWeightsNotFound(
+            f"model weights are not found for architecture '{architecture}' and "
+            f"weights name '{name}'. Available models are"
+            f"{list_all_models_and_weights()}."
+        )
 
 
-def list_available_models_for_weights(weights: str) -> List[str]:
-    res = []
-    for model_name, weights_dict in WEIGHTS.items():
-        for weights_name in weights_dict.keys():
-            if weights_name == weights:
-                res.append(model_name)
-    return res
+register_model_weights(Path(__file__).parent / ".." / "modeldefs")
+
+# Register any user-supplied configurations.
+wsinfer_path = os.environ.get("WSINFER_PATH")
+if wsinfer_path is not None:
+    for path in wsinfer_path.split(":"):
+        register_model_weights(Path(path))
+    del path
+del wsinfer_path
 
 
 def list_all_models_and_weights() -> List[Tuple[str, str]]:
     """Return list of tuples of `(model_name, weights_name)` with available pairs."""
-    res = []
-    for m in WEIGHTS.keys():
-        res.extend([(m, w) for w in WEIGHTS[m].keys()])
-    return res
-
-
-def create_model(model_name: str, weights: str) -> Weights:
-    """Create a model."""
-    if model_name not in list_models():
-        raise ModelNotFoundError(
-            f"'{model_name}' not found. Available models are {list_models()}"
-        )
-    if weights not in list_available_weights_for_model(model_name):
-        raise WeightsNotFoundError(
-            f"The weights available for '{model_name}' are"
-            f" {list_available_weights_for_model(model_name)}.\n"
-            f"The weights '{weights}' are available for the following models:"
-            f" {list_available_models_for_weights(weights)}."
-        )
-
-    # TODO: figure out how to pair model_fn with the Weights instances.
-    model_fn = MODEL_NAME_TO_FUNC[model_name]
-    weights_obj = model_fn(weights=weights)
-    return weights_obj
+    return list(_known_model_weights.keys())

--- a/wsinfer/modellib/models.py
+++ b/wsinfer/modellib/models.py
@@ -19,6 +19,7 @@ import yaml
 from .inceptionv4 import inceptionv4 as _inceptionv4
 from .inceptionv4_no_batchnorm import inceptionv4 as _inceptionv4_no_bn
 from .resnet_preact import resnet34_preact as _resnet34_preact
+from .vgg16mod import vgg16mod as _vgg16mod
 from .transforms import PatchClassification
 
 
@@ -212,6 +213,7 @@ _model_registry: Dict[str, Callable[[int], torch.nn.Module]] = {
     "inceptionv4": _inceptionv4,
     "inceptionv4nobn": _inceptionv4_no_bn,
     "preactresnet34": _resnet34_preact,
+    "vgg16mod": _vgg16mod,
 }
 
 
@@ -233,7 +235,7 @@ def register_model_weights(root: Path):
     modeldefs = list(root.glob("*.yml")) + list(root.glob("*.yaml"))
     for modeldef in modeldefs:
         w = Weights.from_yaml(modeldef)
-        if w.architecture not in timm.list_models() + _model_registry.keys():
+        if w.architecture not in timm.list_models() + list(_model_registry.keys()):
             raise UnknownArchitectureError(f"{w.architecture} implementation not found")
         key = (w.architecture, w.name)
         if key in _known_model_weights:

--- a/wsinfer/modellib/models.py
+++ b/wsinfer/modellib/models.py
@@ -269,4 +269,6 @@ del wsinfer_path
 
 def list_all_models_and_weights() -> List[Tuple[str, str]]:
     """Return list of tuples of `(model_name, weights_name)` with available pairs."""
-    return list(_known_model_weights.keys())
+    vals = list(_known_model_weights.keys())
+    vals.sort()
+    return vals

--- a/wsinfer/modellib/resnet_preact.py
+++ b/wsinfer/modellib/resnet_preact.py
@@ -75,5 +75,5 @@ class PreActResNet(nn.Module):
         return out
 
 
-def resnet34_preact():
-    return PreActResNet(PreActBlock, [3, 4, 6, 3])
+def resnet34_preact(num_classes: int):
+    return PreActResNet(PreActBlock, [3, 4, 6, 3], num_classes=num_classes)

--- a/wsinfer/modellib/run_inference.py
+++ b/wsinfer/modellib/run_inference.py
@@ -217,17 +217,11 @@ def run_inference(
             category=PatchFilesNotFoundWarning,
         )
 
-    if weights.model is None:
-        raise RuntimeError("model cannot be None in the weights object")
-
     model_output_dir = results_dir / "model-outputs"
     model_output_dir.mkdir(exist_ok=True)
 
-    model = weights.model
-    if model is None:
-        raise ValueError("Model was not instantiated... use `create_model`.")
-
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    model = weights.load_model()
     model.eval()
     model.to(device)
 

--- a/wsinfer/modellib/vgg16mod.py
+++ b/wsinfer/modellib/vgg16mod.py
@@ -1,0 +1,20 @@
+"""Implementation of VGG16 in https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7369575."""
+
+import torch
+import torchvision
+
+
+def vgg16mod(num_classes: int) -> torch.nn.Module:
+    """Create modified VGG16 model.
+
+    The classifier of this model is
+        Linear (25,088, 4096)
+        ReLU -> Dropout
+        Linear (1024, num_classes)
+    """
+    model = torchvision.models.vgg16()
+    model.classifier = model.classifier[:4]
+    in_features = model.classifier[0].in_features
+    model.classifier[0] = torch.nn.Linear(in_features, 1024)
+    model.classifier[3] = torch.nn.Linear(1024, num_classes)
+    return model


### PR DESCRIPTION
the `wsinfer run` command now accepts a `--config` option to a yaml file. the options `--model` and `--weights` are mutually exclusive with `--config`.

this is an example of a yaml config file:

```yaml
# Configuration of a breast cancer tumor detection model.
# The models are referenced by the pair of [architecture, weights], so this pair must
# be unique.
architecture: resnet34  # Must be a string.
name: TCGA-BRCA-v1  # Must be a string.
# Where to get the model weights. Either a URL or path to a file.
# If using a URL, set the url_file_name (the name of the file when it is downloaded).
url: https://stonybrookmedicine.box.com/shared/static/dv5bxk6d15uhmcegs9lz6q70yrmwx96p.pt
url_file_name: resnet34-brca-20190613-01eaf604.pt
# If using a relative path, the path is relative to the location of the yaml file.
# file: /path/to/weights.pt
num_classes: 2
transform:
  # These are keyword arguments to the PatchClassification class.
  resize_size: 224  # Must be a single integer.
  mean: [0.7238, 0.5716, 0.6779]  # Must be a list of three floats.
  std: [0.1120, 0.1459, 0.1089]  # Must be a list of three floats.
patch_size_pixels: 350
spacing_um_px: 0.25
class_names:
  - notumor
  - tumor
```